### PR TITLE
Add workflow to publish to CDN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+---
+name: Publish
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - "package.json"
+jobs:
+    build_main:
+        concurrency: build_main_${{ github.head_ref }}
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_TOKEN: ${{ secrets.WHEREBY_GITHUB_TOKEN }}
+        steps:
+            - name: Checkout source code
+              uses: actions/checkout@v2
+
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: "14"
+
+            - name: Install dependencies
+              run: yarn install
+              working-directory: .
+
+            - name: Build
+              run: yarn build
+              working-directory: .
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: eu-west-1
+
+            - uses: jakejarvis/s3-sync-action@master
+              with:
+                  args: --acl public-read --follow-symlinks
+              env:
+                  AWS_S3_BUCKET: whereby-cdn
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  AWS_REGION: "es-west-1"
+                  SOURCE_DIR: "dist/"
+                  DEST_DIR: "embed-test-deploy/"
+
+            - name: Invalidate cloudfront publication
+              run: aws cloudfront create-invalidation --distribution-id=E6H48QPJYYL39 --paths "/embed-test-deploy/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",


### PR DESCRIPTION
This adds a job to publish to CDN whenever there is a new version. Temporarily uploads files to a new folder in the S3 bucket to enable manual verification of the deployed assets.