### PR TITLE
Use real CDN path for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: "es-west-1"
                   SOURCE_DIR: "dist/"
-                  DEST_DIR: "embed-test-deploy/"
+                  DEST_DIR: "embed/"
 
             - name: Invalidate cloudfront publication
-              run: aws cloudfront create-invalidation --distribution-id=E6H48QPJYYL39 --paths "/embed-test-deploy/*"
+              run: aws cloudfront create-invalidation --distribution-id=E6H48QPJYYL39 --paths "/embed/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",


### PR DESCRIPTION
The deploy now works, use correct path to overwrite previous versions.