### PR TITLE
Add npm deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish
+name: Build, test & deploy
 on:
     push:
         branches:
@@ -7,8 +7,9 @@ on:
         paths:
             - "package.json"
 jobs:
-    build_main:
-        concurrency: build_main_${{ github.head_ref }}
+    build_and_test:
+        concurrency: build_and_test_main_${{ github.head_ref }}
+        name: Build & test
         runs-on: ubuntu-latest
         env:
             GITHUB_TOKEN: ${{ secrets.WHEREBY_GITHUB_TOKEN }}
@@ -16,17 +17,24 @@ jobs:
             - name: Checkout source code
               uses: actions/checkout@v2
 
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: "14"
+            - name: Build
+              uses: ./.github/actions/build
 
-            - name: Install dependencies
-              run: yarn install
-              working-directory: .
+            - name: Test
+              run: yarn test
+    deploy_cdn:
+        concurrency: deploy_cdn_main_${{ github.head_ref }}
+        name: Deploy to CDN
+        needs: build_and_test
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_TOKEN: ${{ secrets.WHEREBY_GITHUB_TOKEN }}
+        steps:
+            - name: Checkout source code
+              uses: actions/checkout@v2
 
             - name: Build
-              run: yarn build
-              working-directory: .
+              uses: ./.github/actions/build
 
             - name: Configure AWS Credentials
               uses: aws-actions/configure-aws-credentials@v1
@@ -48,3 +56,21 @@ jobs:
 
             - name: Invalidate cloudfront publication
               run: aws cloudfront create-invalidation --distribution-id=E6H48QPJYYL39 --paths "/embed/*"
+    deploy_npm:
+        concurrency: deploy_npm_main_${{ github.head_ref }}
+        name: Deploy to npm
+        needs: build_and_test
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_TOKEN: ${{ secrets.WHEREBY_GITHUB_TOKEN }}
+        steps:
+            - name: Checkout source code
+              uses: actions/checkout@v2
+
+            - name: Build
+              uses: ./.github/actions/build
+
+            - name: Deploy to npm
+              uses: JS-DevTools/npm-publish@v1
+              with:
+                  token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds job to deploy new npm version. Runs in parallel with CDN deploy job, both depending on the build & test to pass before starting.