### PR TITLE
Add functions to start and stop recording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",

--- a/src/lib/__tests__/index.unit.js
+++ b/src/lib/__tests__/index.unit.js
@@ -69,6 +69,8 @@ describe("@whereby/browser-sdk", () => {
             expect(define).toBeCalledWith(
                 expect.any(String),
                 expect.objectContaining({
+                    startRecording: expect.any(Function),
+                    stopRecording: expect.any(Function),
                     toggleCamera: expect.any(Function),
                     toggleMicrophone: expect.any(Function),
                 })

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -66,20 +66,23 @@ define("WherebyEmbed", {
     },
 
     // Commands
-    toggleCamera(enabled) {
+    _postCommand(command, args = []) {
         if (this.iframe.current) {
             const url = new URL(this.room, `https://${this.subdomain}.whereby.com`);
-            this.iframe.current.contentWindow.postMessage({ command: "toggle_camera", args: [enabled] }, url.origin);
+            this.iframe.current.contentWindow.postMessage({ command, args }, url.origin);
         }
     },
+    startRecording() {
+        this._postCommand("start_recording");
+    },
+    stopRecording() {
+        this._postCommand("stop_recording");
+    },
+    toggleCamera(enabled) {
+        this._postCommand("toggle_camera", [enabled]);
+    },
     toggleMicrophone(enabled) {
-        if (this.iframe.current) {
-            const url = new URL(this.room, `https://${this.subdomain}.whereby.com`);
-            this.iframe.current.contentWindow.postMessage(
-                { command: "toggle_microphone", args: [enabled] },
-                url.origin
-            );
-        }
+        this._postCommand("toggle_microphone", [enabled]);
     },
 
     onmessage({ origin, data }) {


### PR DESCRIPTION
Expose two new functions `startRecording()` and `stopRecording()` to allow integrating apps to control recording state.

Not testable until https://github.com/whereby/pwa/pull/3322 is merged. 