### PR TITLE
Remove jslib-api private dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "plugins": ["jest"],
     "rules": {
         "no-console": ["error", { "allow": ["warn", "error"] }],
+        "@typescript-eslint/ban-ts-comment": 0,
         "@typescript-eslint/no-namespace": "off"
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 *.log
+storybook-static/
+

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@storybook/builder-webpack5": "^6.5.14",
     "@storybook/manager-webpack5": "^6.5.14",
     "@storybook/react": "^6.5.14",
+    "@types/btoa": "^1.2.3",
     "@types/jest": "^29.2.4",
     "@types/react": "^18.0.26",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
@@ -62,6 +63,8 @@
     "@swc/helpers": "^0.3.13",
     "@whereby/jslib-api": "^77.17.0",
     "@whereby/jslib-commons": "github:whereby/jslib-commons#43.1.2",
+    "axios": "^1.2.3",
+    "btoa": "^1.2.1",
     "heresy": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "yarn test:lint && yarn test:unit",
     "test:lint": "eslint src/",
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:unit:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
@@ -38,6 +39,7 @@
     "@storybook/manager-webpack5": "^6.5.14",
     "@storybook/react": "^6.5.14",
     "@types/btoa": "^1.2.3",
+    "@types/chrome": "^0.0.210",
     "@types/jest": "^29.2.4",
     "@types/react": "^18.0.26",
     "@typescript-eslint/eslint-plugin": "^5.46.1",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -12,7 +12,8 @@ import {
     OrganizationService,
     OrganizationServiceCache,
     RoomService,
-} from "@whereby/jslib-api";
+} from "./api";
+
 import { LocalParticipant, RemoteParticipant, StreamState } from "./RoomParticipant";
 
 import ServerSocket, {

--- a/src/lib/api/Credentials.ts
+++ b/src/lib/api/Credentials.ts
@@ -1,0 +1,45 @@
+import { extractJson, extractNullOrString, extractString } from "./extractUtils";
+import { Json } from "./Response";
+
+interface CredentialsOptions {
+    uuid: string;
+    hmac: string;
+    userId?: string;
+}
+
+export default class Credentials {
+    credentials: {
+        uuid: CredentialsOptions["uuid"];
+    };
+
+    hmac: CredentialsOptions["hmac"];
+    userId: CredentialsOptions["userId"];
+
+    constructor(
+        uuid: CredentialsOptions["uuid"],
+        hmac: CredentialsOptions["hmac"],
+        userId: CredentialsOptions["userId"] = undefined
+    ) {
+        this.credentials = {
+            uuid,
+        };
+        this.hmac = hmac;
+        this.userId = userId;
+    }
+
+    toJson(): Json {
+        return {
+            credentials: this.credentials,
+            hmac: this.hmac,
+            ...(this.userId && { userId: this.userId }),
+        };
+    }
+
+    static fromJson(json: Json): Credentials {
+        return new Credentials(
+            extractString(extractJson(json, "credentials"), "uuid"),
+            extractString(json, "hmac"),
+            extractNullOrString(json, "userId") || undefined
+        );
+    }
+}

--- a/src/lib/api/HttpClient.ts
+++ b/src/lib/api/HttpClient.ts
@@ -1,0 +1,93 @@
+import assert from "assert";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import Response from "./Response";
+import { assertString } from "./parameterAssertUtils";
+
+export type HttpClientRequestConfig = AxiosRequestConfig;
+
+export interface IHttpClient {
+    request(url: string, options: HttpClientRequestConfig): Promise<Response>;
+}
+
+function _getAbsoluteUrl({ baseUrl, url }: { baseUrl?: string; url: string }): string {
+    assert.ok(typeof url === "string", "url<String> is required");
+    return baseUrl ? baseUrl + url : url;
+}
+
+/**
+ * Class used for making http calls. This is just a pure
+ * wrapper around the http lib that we decide to use,
+ * so that we can switch implementations.
+ */
+export default class HttpClient implements IHttpClient {
+    _baseUrl: string;
+    /**
+     * Creates an HttpClient instance.
+     *
+     * @param {string} [baseUrl] - The base URL where all requests are made.
+     */
+    constructor({ baseUrl }: { baseUrl: string }) {
+        assertString(baseUrl, "baseUrl");
+
+        this._baseUrl = baseUrl;
+    }
+
+    private _requestAxios(url: string, options: HttpClientRequestConfig): Promise<AxiosResponse> {
+        const axiosOptions = Object.assign({}, options, {
+            url,
+            baseURL: this._baseUrl,
+        });
+
+        return axios.request(axiosOptions);
+    }
+
+    /**
+     * Wrapper for the axios API
+     *
+     * @param {string} url - Required. URL (appended to base URL) where API call will be made
+     * @param {object} options - Required. Contains the data needed for the fetch API
+     * @return {Promise<Response>} - A promise which will return a Response object (https://developer.mozilla.org/en-US/docs/Web/API/Response)
+     */
+    request(url: string, options: HttpClientRequestConfig): Promise<Response> {
+        assertString(url, "url");
+        assert.equal(url[0], "/", 'url<String> only accepts relative URLs beginning with "/".');
+        assert.ok(options, "options are required");
+
+        return this._requestAxios(url, options)
+            .then((response) => {
+                const { data, headers, status, statusText, config } = response;
+                const requestUrl =
+                    config && config.url ? _getAbsoluteUrl({ baseUrl: config.baseURL, url: config.url }) : null;
+
+                return new Response({
+                    data,
+                    headers,
+                    status,
+                    statusText,
+                    url: requestUrl,
+                });
+            })
+            .catch((error: AxiosError) => {
+                const responseObject = error.response;
+
+                if (!responseObject) {
+                    // Either server error or something else.
+                    throw new Error("Could not make the request.");
+                }
+
+                const { data, headers, status, statusText, config } = responseObject;
+                const requestUrl =
+                    config && config.url ? _getAbsoluteUrl({ baseUrl: config.baseURL, url: config.url }) : null;
+
+                return Promise.reject(
+                    new Response({
+                        data,
+                        headers,
+                        status,
+                        statusText,
+                        url: requestUrl,
+                    })
+                );
+            });
+    }
+}

--- a/src/lib/api/HttpClient.ts
+++ b/src/lib/api/HttpClient.ts
@@ -1,9 +1,11 @@
 import assert from "assert";
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
-import Response from "./Response";
+import Response, { ErrorResponseObject } from "./Response";
 import { assertString } from "./parameterAssertUtils";
 
-export type HttpClientRequestConfig = AxiosRequestConfig;
+export type HttpClientRequestConfig =
+    | AxiosRequestConfig
+    | { [key: string]: any };
 
 export interface IHttpClient {
     request(url: string, options: HttpClientRequestConfig): Promise<Response>;
@@ -75,7 +77,7 @@ export default class HttpClient implements IHttpClient {
                     throw new Error("Could not make the request.");
                 }
 
-                const { data, headers, status, statusText, config } = responseObject;
+                const { data, headers, status, statusText, config } = responseObject as ErrorResponseObject;
                 const requestUrl =
                     config && config.url ? _getAbsoluteUrl({ baseUrl: config.baseURL, url: config.url }) : null;
 

--- a/src/lib/api/MultipartHttpClient.ts
+++ b/src/lib/api/MultipartHttpClient.ts
@@ -1,0 +1,53 @@
+import assert from "assert";
+import { HttpClientRequestConfig, IHttpClient } from "./HttpClient";
+import Response from "./Response";
+
+/**
+ * ApiClient for doing multipart/form-data requests.
+ */
+export default class MultipartHttpClient implements IHttpClient {
+    _httpClient: IHttpClient;
+
+    constructor({ httpClient }: { httpClient: IHttpClient }) {
+        assert.ok(httpClient, "httpClient is required");
+
+        this._httpClient = httpClient;
+    }
+
+    /**
+     * Convert the provided object to a FormData object containing the same keys and values.
+     * @param {object} data - the data to convert.
+     * @returns {FormData}
+     */
+    static dataToFormData(data: Record<string, string>): FormData {
+        assert.ok(data, "data is required");
+
+        const fd = new FormData();
+        Object.keys(data).forEach((key) => {
+            const value = data[key];
+            fd.append(key, value);
+        });
+        return fd;
+    }
+
+    /**
+     * Request a resource using multipart/form-data encoding.
+     *
+     * @param {string} url - the url to request
+     * @param {object} options - Required. Contains the data needed for the fetch API
+     * @return {Promise<Response>} - A promise which will return a Response object (https://developer.mozilla.org/en-US/docs/Web/API/Response)
+     */
+    request(url: string, options: HttpClientRequestConfig = {}): Promise<Response> {
+        const headers = Object.assign(options.headers || {}, {
+            "Content-Type": undefined,
+        });
+
+        return this._httpClient.request(
+            url,
+            Object.assign(options, {
+                headers,
+                transformRequest: MultipartHttpClient.dataToFormData,
+            })
+        );
+    }
+}

--- a/src/lib/api/OrganizationApiClient.ts
+++ b/src/lib/api/OrganizationApiClient.ts
@@ -1,0 +1,64 @@
+import ApiClient from "./ApiClient";
+import assert from "assert";
+import { assertInstanceOf, assertString } from "./parameterAssertUtils";
+import { HttpClientRequestConfig } from "./HttpClient";
+import Response from "./Response";
+import Organization from "./models/Organization";
+
+const noOrganization = () => Promise.resolve(undefined);
+
+export type FetchOrganizationFunction = () => Promise<Organization | undefined>;
+
+/**
+ * Class used for all Whereby organization API calls.
+ */
+export default class OrganizationApiClient {
+    private _apiClient: ApiClient;
+    private _fetchOrganization: FetchOrganizationFunction;
+    /**
+     * Create an OrganizationApiClient instance.
+     *
+     * @param {ApiClient} [apiClient] - The apiClient to use.
+     * @param {Function} [fetchOrganization] - function that returns a promise with the organization.
+     */
+    constructor({
+        apiClient,
+        fetchOrganization = noOrganization,
+    }: {
+        apiClient: ApiClient;
+        fetchOrganization?: FetchOrganizationFunction;
+    }) {
+        this._apiClient = assertInstanceOf(apiClient, ApiClient);
+        assert.ok(typeof fetchOrganization === "function", "fetchOrganization<Function> is required");
+
+        this._fetchOrganization = fetchOrganization;
+        this._apiClient = apiClient;
+    }
+
+    _callRequestMethod(
+        method: "request" | "requestMultipart",
+        url: string,
+        options: HttpClientRequestConfig
+    ): Promise<Response> {
+        assertString(url, "url");
+        assert.equal(url[0], "/", 'url<String> only accepts relative URLs beginning with "/".');
+        assert.ok(options, "options are required");
+        return this._fetchOrganization().then((organization) => {
+            if (!organization) {
+                return this._apiClient[method](url, options);
+            }
+
+            const { organizationId } = organization;
+
+            return this._apiClient[method](`/organizations/${encodeURIComponent(organizationId)}${url}`, options);
+        });
+    }
+
+    request(url: string, options: HttpClientRequestConfig): Promise<Response> {
+        return this._callRequestMethod("request", url, options);
+    }
+
+    requestMultipart(url: string, options: HttpClientRequestConfig): Promise<Response> {
+        return this._callRequestMethod("requestMultipart", url, options);
+    }
+}

--- a/src/lib/api/Response.ts
+++ b/src/lib/api/Response.ts
@@ -1,0 +1,26 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Json = string | number | boolean | null | Array<Json> | { [key: string]: Json };
+
+interface ResponseOptions {
+    data?: Json;
+    headers?: Record<string, any>;
+    status?: number;
+    statusText?: string;
+    url?: string | null;
+}
+
+export default class Response {
+    data: Json;
+    headers: Record<string, unknown>;
+    status: number;
+    statusText: string;
+    url: string | null;
+
+    constructor(initialValues: ResponseOptions = {}) {
+        this.data = initialValues.data === undefined ? {} : initialValues.data;
+        this.headers = initialValues.headers || {};
+        this.status = initialValues.status || 200;
+        this.statusText = initialValues.statusText || "OK";
+        this.url = initialValues.url || null;
+    }
+}

--- a/src/lib/api/Response.ts
+++ b/src/lib/api/Response.ts
@@ -1,6 +1,14 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Json = string | number | boolean | null | Array<Json> | { [key: string]: Json };
 
+export type ErrorResponseObject = {
+    data?: Json;
+    headers?: Record<string, any>;
+    status?: number;
+    statusText?: string;
+    config?: { url?: string; baseURL?: string } | null;
+};
+
 interface ResponseOptions {
     data?: Json;
     headers?: Record<string, any>;

--- a/src/lib/api/credentialsService/index.ts
+++ b/src/lib/api/credentialsService/index.ts
@@ -1,0 +1,159 @@
+import EventEmitter from "events";
+
+import DeviceService from "../deviceService/index";
+import AbstractStore from "../modules/AbstractStore";
+import ChromeStorageStore from "../modules/ChromeStorageStore";
+import LocalStorageStore from "../modules/LocalStorageStore";
+import { assertInstanceOf } from "../parameterAssertUtils";
+import ApiClient from "../ApiClient";
+import localStorage from "../localStorageWrapper";
+import { Credentials } from "..";
+
+/**
+ * Events triggered by this service
+ */
+export const events = {
+    CREDENTIALS_SAVED: "credentials_saved",
+};
+
+export default class CredentialsService extends EventEmitter {
+    _deviceService: DeviceService;
+    _credentialsStore: AbstractStore;
+    credentialsPromise?: Promise<Credentials | null>;
+
+    /**
+     * Service to manage Whereby's Rest API credentials.
+     *
+     * @param {ObjectStore} credentialsStore - Store to manage the credentials.
+     */
+    constructor({
+        deviceService,
+        credentialsStore,
+    }: {
+        deviceService: DeviceService;
+        credentialsStore: AbstractStore;
+    }) {
+        super();
+        this._deviceService = assertInstanceOf(deviceService, DeviceService);
+        this._credentialsStore = credentialsStore;
+    }
+
+    static create({
+        baseUrl,
+        storeName = "CredentialsStorage",
+        storeType = "localStorage",
+    }: {
+        baseUrl: string;
+        storeName?: string;
+        storeType?: "localStorage" | "chromeStorage";
+    }): CredentialsService {
+        const deviceService = new DeviceService({
+            apiClient: new ApiClient({ baseUrl }),
+        });
+
+        let credentialsStore = null;
+
+        if (storeType === "localStorage") {
+            credentialsStore = new LocalStorageStore(storeName, localStorage);
+        } else if (storeType === "chromeStorage") {
+            credentialsStore = new ChromeStorageStore(storeName, window["chrome"].storage.local);
+        } else {
+            throw new Error(`Unknown store type: ${storeType}`);
+        }
+
+        return new CredentialsService({
+            deviceService,
+            credentialsStore,
+        });
+    }
+    /**
+     * Contacts the REST API to get new credentials. DO NOT USE directly, call getCredentials() instead.
+     *
+     * @see getCredentials
+     * @returns {Promise.<Credentials>} - Promise that resolves with the credentials.
+     */
+    _fetchNewCredentialsFromApi(): Promise<Credentials | null> {
+        const credentialsStore = this._credentialsStore;
+        return new Promise((resolve) => {
+            const fetchCredentials = () => {
+                this._deviceService
+                    .getCredentials()
+                    .then((credentials) => {
+                        return credentialsStore
+                            .save(credentials ? credentials.toJson() : null)
+                            .then(() => resolve(credentials));
+                    })
+                    .catch(() => {
+                        setTimeout(fetchCredentials, 2000);
+                    });
+            };
+            fetchCredentials();
+        });
+    }
+
+    /**
+     * Returns the current credentials without triggering an API request to get new ones.
+     * If no credentials are currently available it will return null.
+     *
+     * @returns {?Credentials} - The credentials currently in use, null otherwise.
+     */
+    getCurrentCredentials(): Promise<Credentials | null> {
+        return this._credentialsStore.loadOrDefault(null).then((json) => (json ? Credentials.fromJson(json) : null));
+    }
+
+    /**
+     * Returns a promise that will contain the credentials for this client.
+     * If no credentials are available in local storage, new ones will be fetched from the server.
+     *
+     * @returns {Promise.<Credentials>} - Promise that resolves with the credentials.
+     */
+    getCredentials(): Promise<Credentials | null> {
+        if (!this.credentialsPromise) {
+            this.credentialsPromise = this.getCurrentCredentials().then((storedCredentials) => {
+                if (storedCredentials) {
+                    return storedCredentials;
+                }
+
+                return this._fetchNewCredentialsFromApi();
+            });
+        }
+
+        return this.credentialsPromise;
+    }
+
+    /**
+     * Saves new credentials which replace the existing ones and abort any pending request to get new ones.
+     *
+     * @param {Credentials} credentials - New credentials to store.
+     */
+    saveCredentials(credentials: Credentials): Promise<Credentials> {
+        this.credentialsPromise = undefined;
+        return this._credentialsStore.save(credentials.toJson()).then(() => {
+            this.emit(events.CREDENTIALS_SAVED, credentials);
+            return credentials;
+        });
+    }
+
+    /**
+     * It will set the userId for the current credentials.
+     *
+     * @param userId - The user id to set.
+     */
+    setUserId(userId: string | null): Promise<void> {
+        // Used to ensure that the userId is changed if localStorage has been modified by another tab
+        return this.getCurrentCredentials()
+            .then((storedCredentials) => {
+                if (!storedCredentials) {
+                    console.error("Illegal state: no credentials to set user id for."); // eslint-disable-line no-console
+                }
+
+                const userIdChangedFromLocalStorage = storedCredentials === null || storedCredentials.userId !== userId;
+                if (!userIdChangedFromLocalStorage) {
+                    return undefined;
+                }
+
+                return this._credentialsStore.save(Object.assign({}, storedCredentials?.toJson(), { userId }));
+            })
+            .then(() => undefined);
+    }
+}

--- a/src/lib/api/credentialsService/test/index.spec.ts
+++ b/src/lib/api/credentialsService/test/index.spec.ts
@@ -1,0 +1,176 @@
+// @ts-nocheck
+import sinon from "sinon";
+import Credentials from "../../Credentials";
+import CredentialsService, { events } from "../index";
+import LocalStorageStore from "../../modules/LocalStorageStore";
+import DeviceService from "../../deviceService/index";
+
+describe("CredentialsService", () => {
+    let deviceService;
+    let credentialsStore;
+    let credentialsService;
+    let storedCredentials;
+
+    beforeEach(() => {
+        credentialsStore = sinon.createStubInstance(LocalStorageStore);
+        deviceService = sinon.createStubInstance(DeviceService);
+        credentialsService = new CredentialsService({
+            deviceService,
+            credentialsStore,
+        });
+        storedCredentials = new Credentials("test-stored-uuid", "test-stored-hmac");
+    });
+
+    describe("getCurrentCredentials", () => {
+        it("should load credentials from the store", async () => {
+            credentialsStore.loadOrDefault.resolves(storedCredentials.toJson());
+
+            const result = await credentialsService.getCurrentCredentials();
+
+            expect(result).to.eql(storedCredentials);
+        });
+
+        // eslint-disable-next-line mocha/no-identical-title
+        it("should load credentials from the store", () => {
+            credentialsStore.loadOrDefault.resolves(storedCredentials.toJson());
+
+            credentialsService.getCurrentCredentials();
+
+            return expect(credentialsStore.loadOrDefault).to.have.been.called();
+        });
+    });
+
+    describe("getCredentials", () => {
+        describe("when no credentials are available in localStorage", () => {
+            let apiCredentials;
+            beforeEach(() => {
+                apiCredentials = new Credentials("test-fetched-uuid", "test-fetched-hmac");
+                credentialsStore.loadOrDefault.resolves(null);
+                credentialsStore.save.resolves();
+                deviceService.getCredentials.resolves(apiCredentials);
+            });
+
+            it("should save the fetched credentials to credentialsStore", () => {
+                const promise = credentialsService.getCredentials();
+
+                return promise.then(() => {
+                    expect(credentialsStore.save).to.have.been.calledWithExactly(apiCredentials.toJson());
+                });
+            });
+
+            it("should fetch new credentials from the API", () => {
+                const promise = credentialsService.getCredentials();
+
+                return promise.then(() => {
+                    expect(deviceService.getCredentials.withArgs()).to.have.been.calledOnce();
+                });
+            });
+
+            it("should resolve with the credentials from the api", async () => {
+                const result = await credentialsService.getCredentials();
+
+                return expect(result).to.eql(apiCredentials);
+            });
+        });
+
+        describe("when credentials are available in localStorage", () => {
+            beforeEach(() => {
+                credentialsStore.loadOrDefault.resolves(storedCredentials);
+                deviceService.getCredentials.resolves(null);
+            });
+
+            it("should not fetch new credentials from the api", () => {
+                const promise = credentialsService.getCredentials();
+
+                return promise.then(() => {
+                    expect(deviceService.getCredentials).to.not.have.been.called();
+                });
+            });
+
+            it("should return credentials from localstorage", async () => {
+                const result = await credentialsService.getCredentials();
+
+                expect(result).to.eql(storedCredentials);
+            });
+        });
+    });
+
+    describe("saveCredentials", () => {
+        it("should save the credentials to localStorage", () => {
+            credentialsStore.save.resolves();
+
+            const promise = credentialsService.saveCredentials(storedCredentials);
+
+            return promise.then(() => {
+                expect(credentialsStore.save).to.have.been.calledWithExactly(storedCredentials.toJson());
+            });
+        });
+
+        it("should fire the CREDENTIALS_SAVED event", () => {
+            credentialsStore.save.resolves();
+            const callback = sinon.stub();
+            credentialsService.on(events.CREDENTIALS_SAVED, callback);
+
+            const promise = credentialsService.saveCredentials(storedCredentials);
+
+            return promise.then(() => {
+                expect(callback).to.have.been.called();
+            });
+        });
+    });
+
+    describe("setUserId", () => {
+        const mockUserId = "1234ef-987654-a1b2cd3e";
+
+        describe("when no credentials are stored", () => {
+            beforeEach(() => {
+                sinon.stub(console, "error");
+                credentialsStore.loadOrDefault.resolves(null);
+            });
+
+            afterEach(() => {
+                console.error.restore(); // eslint-disable-line no-console
+            });
+
+            it("should call log an error", () => {
+                const promise = credentialsService.setUserId(mockUserId);
+
+                return promise.then(() => {
+                    expect(console.error).to.have.been.called(); // eslint-disable-line no-console
+                });
+            });
+
+            it("should return undefined", async () => {
+                const result = await credentialsService.setUserId(mockUserId);
+
+                expect(result).to.eql(undefined);
+            });
+        });
+
+        describe("when have been credentials have been stored", () => {
+            [null, "some-new-userId"].forEach((newUserId) => {
+                let credentialsWithUserId;
+                beforeEach(() => {
+                    credentialsWithUserId = new Credentials("some-uuid", "some-hmac", "some-userId");
+                    credentialsStore.loadOrDefault.resolves(credentialsWithUserId);
+                });
+
+                it("should return undefined", async () => {
+                    const result = await credentialsService.setUserId(newUserId);
+
+                    expect(result).to.eql(undefined);
+                });
+
+                it("should set the userId property in the credentials and store them when it has changed", () => {
+                    const expectedCredentials = Object.assign({}, credentialsWithUserId, { userId: newUserId });
+
+                    const promise = credentialsService.setUserId(newUserId);
+
+                    return promise.then(() => {
+                        expect(credentialsStore.save).to.have.been.calledWithExactly(expectedCredentials);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/src/lib/api/deviceService/index.ts
+++ b/src/lib/api/deviceService/index.ts
@@ -1,0 +1,42 @@
+import ApiClient from "../ApiClient";
+import { assertInstanceOf } from "../parameterAssertUtils";
+import Credentials from "../Credentials";
+
+/**
+ * Related to device calls needed to obtain credentials
+ */
+export default class DeviceService {
+    _apiClient: ApiClient;
+
+    constructor({ apiClient }: { apiClient: ApiClient }) {
+        this._apiClient = assertInstanceOf(apiClient, ApiClient);
+    }
+
+    /**
+     * Get's the device credentials needed for most of the other API services
+     *
+     * @return {Promise} A promise which is fulfilled or failed based on the
+     * response.
+     */
+    getCredentials(): Promise<Credentials | null> {
+        return this._apiClient
+            .request("/devices", {
+                method: "post",
+            })
+            .then(({ data }) => {
+                return Credentials.fromJson(data);
+            })
+            .catch((error) => {
+                if (error.response) {
+                    // The request was made, but the server responded with a status code
+                    // that falls out of the range of 2xx
+                    if (error.response.status === 404) {
+                        return null;
+                    }
+                }
+
+                // Something happened in setting up the request that triggered an Error
+                throw error;
+            });
+    }
+}

--- a/src/lib/api/deviceService/tests/index.spec.ts
+++ b/src/lib/api/deviceService/tests/index.spec.ts
@@ -1,0 +1,74 @@
+import sinon from "sinon";
+import DeviceService from "../index";
+import ApiClient from "../../ApiClient";
+import Credentials from "../../Credentials";
+import { itShouldThrowIfInvalid } from "../../test/helpers";
+import { expect } from "chai";
+import Response from "../../Response";
+
+const credentials = {
+    credentials: {
+        uuid: "12345",
+    },
+    hmac: "67890",
+};
+
+describe("deviceService", () => {
+    let apiClient: sinon.SinonStubbedInstance<ApiClient>;
+    let deviceService: DeviceService;
+
+    beforeEach(() => {
+        apiClient = sinon.createStubInstance(ApiClient);
+        deviceService = new DeviceService({ apiClient });
+    });
+
+    describe("constructor", () => {
+        itShouldThrowIfInvalid(
+            "apiClient",
+            () =>
+                new DeviceService({
+                    //@ts-expect-error
+                    apiClient: undefined,
+                })
+        );
+    });
+
+    describe("getCredentials", () => {
+        const url = "/devices";
+        const method = "post";
+
+        beforeEach(() => {
+            apiClient.request.resolves(new Response({ data: credentials }));
+        });
+
+        it("should call request with correct params", () => {
+            return deviceService.getCredentials().then(() => {
+                expect(apiClient.request).has.been.calledWithExactly(url, {
+                    method,
+                });
+            });
+        });
+
+        it("should be fulfilled with the credentials success", async () => {
+            const result = await deviceService.getCredentials();
+
+            expect(result).to.eql(new Credentials(credentials.credentials.uuid, credentials.hmac));
+        });
+
+        it("should fail if the request failed", () => {
+            const error = new Error("some error");
+            apiClient.request.rejects(error);
+
+            return expect(deviceService.getCredentials()).to.eventually.be.rejected().and.be.equal(error);
+        });
+
+        it("should return null if the server is down", async () => {
+            const response = { response: { status: 404 } };
+            apiClient.request.rejects(response);
+
+            const result = await deviceService.getCredentials();
+
+            expect(result).to.eql(null);
+        });
+    });
+});

--- a/src/lib/api/deviceService/tests/index.spec.ts
+++ b/src/lib/api/deviceService/tests/index.spec.ts
@@ -1,10 +1,10 @@
-import sinon from "sinon";
 import DeviceService from "../index";
 import ApiClient from "../../ApiClient";
 import Credentials from "../../Credentials";
 import { itShouldThrowIfInvalid } from "../../test/helpers";
-import { expect } from "chai";
 import Response from "../../Response";
+
+jest.mock("../../ApiClient");
 
 const credentials = {
     credentials: {
@@ -14,11 +14,11 @@ const credentials = {
 };
 
 describe("deviceService", () => {
-    let apiClient: sinon.SinonStubbedInstance<ApiClient>;
+    let apiClient: jest.Mocked<ApiClient>;
     let deviceService: DeviceService;
 
     beforeEach(() => {
-        apiClient = sinon.createStubInstance(ApiClient);
+        apiClient = new ApiClient() as jest.Mocked<ApiClient>;
         deviceService = new DeviceService({ apiClient });
     });
 
@@ -38,37 +38,37 @@ describe("deviceService", () => {
         const method = "post";
 
         beforeEach(() => {
-            apiClient.request.resolves(new Response({ data: credentials }));
+            apiClient.request.mockResolvedValue(new Response({ data: credentials }));
         });
 
-        it("should call request with correct params", () => {
-            return deviceService.getCredentials().then(() => {
-                expect(apiClient.request).has.been.calledWithExactly(url, {
-                    method,
-                });
+        it("should call request with correct params", async () => {
+            await deviceService.getCredentials();
+
+            expect(apiClient.request).toBeCalledWith(url, {
+                method,
             });
         });
 
         it("should be fulfilled with the credentials success", async () => {
             const result = await deviceService.getCredentials();
 
-            expect(result).to.eql(new Credentials(credentials.credentials.uuid, credentials.hmac));
+            expect(result).toEqual(new Credentials(credentials.credentials.uuid, credentials.hmac));
         });
 
-        it("should fail if the request failed", () => {
+        it("should fail if the request failed", async () => {
             const error = new Error("some error");
-            apiClient.request.rejects(error);
+            apiClient.request.mockRejectedValue(error);
 
-            return expect(deviceService.getCredentials()).to.eventually.be.rejected().and.be.equal(error);
+            await expect(deviceService.getCredentials()).rejects.toThrow(error);
         });
 
         it("should return null if the server is down", async () => {
             const response = { response: { status: 404 } };
-            apiClient.request.rejects(response);
+            apiClient.request.mockRejectedValue(response);
 
             const result = await deviceService.getCredentials();
 
-            expect(result).to.eql(null);
+            expect(result).toEqual(null);
         });
     });
 });

--- a/src/lib/api/extractUtils.ts
+++ b/src/lib/api/extractUtils.ts
@@ -1,0 +1,160 @@
+import { assertArray, assertBoolean, assertNumber, assertRecord, assertString } from "./parameterAssertUtils";
+import { Json } from "./Response";
+
+export type Extractor<T> = (data: Json, propertyName: string) => T;
+export type Transformer<T> = (data: Json) => T;
+
+/**
+ * Utility function to transform the given transformer function into a
+ * function that handles `undefined` and `null` values.
+ *
+ * @param transformer - Function to transform
+ * @returns the transformed function.
+ */
+export function nullOrTransform<T>(transform: Transformer<T>): Transformer<T | null> {
+    return (data: Json): T | null => {
+        return data === null || data === undefined ? null : transform(data);
+    };
+}
+
+/**
+ * Utility function to transform the given extract function to allow
+ * `undefined` and `null` values.
+ * @param extract - Function to transform
+ * @returns the transformed function.
+ */
+export function nullOrExtract<T>(extract: Extractor<T>): Extractor<T | null> {
+    return (data: Json, propertyName: string): T | null => {
+        const record = assertRecord(data, "data");
+
+        const value = record[propertyName];
+        return value === null || value === undefined ? null : extract(data, propertyName);
+    };
+}
+
+/**
+ * Extract a boolean from the given Json object.
+ * If the value is not a boolean, an error is thrown.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @returns the extracted value
+ */
+export function extractBoolean(data: Json, propertyName: string): boolean {
+    const record = assertRecord(data, "data");
+    return assertBoolean(record[propertyName], propertyName);
+}
+
+/**
+ * Extract a string from the given Json object.
+ * If the value is not a string, an error is thrown.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @returns the extracted value
+ */
+export function extractString(data: Json, propertyName: string): string {
+    const record = assertRecord(data, "data");
+    return assertString(record[propertyName], propertyName);
+}
+
+export const extractNullOrString = nullOrExtract(extractString);
+
+/**
+ * Extract a number from the given Json object.
+ * If the value is not a number, an error is thrown.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @returns the extracted value
+ */
+export function extractNumber(data: Json, propertyName: string): number {
+    const record = assertRecord(data, "data");
+    return assertNumber(record[propertyName], propertyName);
+}
+
+export const extractNullOrNumber = nullOrExtract(extractNumber);
+
+/**
+ * Extract a Date from the given Json object.
+ * If the value is not a valid Date, an error is thrown.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @returns the extracted value
+ */
+export function extractDate(data: Json, propertyName: string): Date {
+    const dateString = extractString(data, propertyName);
+    const d = new Date(dateString);
+    if (isNaN(d.getTime())) {
+        throw new Error(`Invalid date for ${dateString}`);
+    }
+
+    return d;
+}
+
+export const extractNullOrDate: (data: Json, propertyName: string) => Date | null = nullOrExtract(extractDate);
+
+/**
+ * Extract an Array from the given Json object.
+ * If the value is not a valid Array, an error is thrown.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @returns the extracted value
+ **/
+export function extractArrayOfJson(data: Json, propertyName: string): Array<Json> {
+    const record = assertRecord(data, "data");
+    return assertArray(record[propertyName], propertyName) as Array<Json>;
+}
+
+/**
+ * Extract an Array from the given Json object and run the provided
+ * transformer on all of the provided values.
+ * If the value is not a valid Array, an error is thrown.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @param transformer - A function to transform all the Json elements extracted from the parameter
+ * @returns the extracted value
+ **/
+export function extractArray<T>(data: Json, propertyName: string, transformer: Transformer<T>): Array<T> {
+    return extractArrayOfJson(data, propertyName).map((value) => transformer(value));
+}
+
+/**
+ * Extract a Json object from the given Json object.
+ * If the value is not a valid Json object, an error is thrown.
+ *
+ * Note, if the extracted value is undefined, null will be returned
+ * since the extractor functions don't distinguish an undefined value
+ * and a null value.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @returns the extracted value
+ */
+export function extractJson(data: Json, propertyName: string): Json {
+    const record = assertRecord(data, "data") as Record<string, Json>;
+
+    const value = record[propertyName];
+    return value === undefined ? null : value;
+}
+
+/**
+ * Extract a Json object from the given Json object and transform
+ * that value using the given transformer function.
+ * If the provided json object is not a valid Json object, an error is thrown.
+ *
+ * Note, if the extracted value is undefined, null will be returned
+ * since the extractor functions don't distinguish an undefined value
+ * and a null value.
+ *
+ * @param data - the object to extract the value from
+ * @param propertyName - the name of the parameter to extract
+ * @param transformer - A function to transform the extracted value
+ * @returns the extracted and transformed value
+ **/
+export function extractJsonWithTransform<T>(data: Json, propertyName: string, transformer: Transformer<T>): T {
+    return transformer(extractJson(data, propertyName));
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,8 @@
+export { default as ApiClient } from "./ApiClient"
+export { default as CredentialsService } from "./credentialsService"
+export { default as Credentials } from "./Credentials"
+export { default as OrganizationApiClient } from "./OrganizationApiClient"
+export { default as OrganizationService } from "./organizationService"
+export { default as OrganizationServiceCache } from "./organizationServiceCache"
+export { default as RoomService } from "./roomService"
+

--- a/src/lib/api/localStorageWrapper/index.ts
+++ b/src/lib/api/localStorageWrapper/index.ts
@@ -1,0 +1,15 @@
+let localStorage;
+try {
+    localStorage = self.localStorage;
+} catch (e) {
+    localStorage = {
+        getItem: (): undefined => undefined,
+        key: (): undefined => undefined,
+        setItem: (): undefined => undefined,
+        removeItem: (): undefined => undefined,
+        hasOwnProperty: (): undefined => undefined,
+        length: 0,
+    };
+}
+
+export default localStorage as Storage;

--- a/src/lib/api/models/Account.ts
+++ b/src/lib/api/models/Account.ts
@@ -1,0 +1,48 @@
+import { assertBoolean } from "../parameterAssertUtils";
+import EmbeddedFreeTierStatus from "./account/EmbeddedFreeTierStatus";
+
+interface AccountProps {
+    basePlanId: string | null;
+    isDeactivated: boolean;
+    isOnTrial: boolean;
+    onTrialUntil: Date | null;
+    trialStatus: string | null;
+    embeddedFreeTierStatus: EmbeddedFreeTierStatus | null;
+}
+export default class Account {
+    basePlanId: string | null;
+    embeddedFreeTierStatus: EmbeddedFreeTierStatus | null;
+    isDeactivated: boolean;
+    isOnTrial: boolean;
+    onTrialUntil: Date | null;
+    trialStatus: string | null;
+
+    constructor({
+        basePlanId,
+        embeddedFreeTierStatus,
+        isDeactivated,
+        isOnTrial,
+        onTrialUntil,
+        trialStatus,
+    }: AccountProps) {
+        this.basePlanId = basePlanId;
+        this.isDeactivated = isDeactivated;
+        this.isOnTrial = isOnTrial;
+        this.onTrialUntil = onTrialUntil || null;
+        this.trialStatus = trialStatus || null;
+        this.embeddedFreeTierStatus = embeddedFreeTierStatus || null;
+    }
+
+    static fromJson(data: Record<string, unknown>): Account {
+        return new Account({
+            basePlanId: typeof data.basePlanId === "string" ? data.basePlanId : null,
+            isDeactivated: assertBoolean(data.isDeactivated, "isDeactivated"),
+            isOnTrial: assertBoolean(data.isOnTrial, "isOnTrial"),
+            onTrialUntil: typeof data.onTrialUntil === "string" ? new Date(data.onTrialUntil) : null,
+            trialStatus: typeof data.trialStatus === "string" ? data.trialStatus : null,
+            embeddedFreeTierStatus: data.embeddedFreeTierStatus
+                ? EmbeddedFreeTierStatus.fromJson(data.embeddedFreeTierStatus as Record<string, unknown>)
+                : null,
+        });
+    }
+}

--- a/src/lib/api/models/Meeting.ts
+++ b/src/lib/api/models/Meeting.ts
@@ -1,0 +1,42 @@
+import { extractDate, extractNullOrString, extractString } from "../extractUtils";
+import { assertString, assertInstanceOf } from "../parameterAssertUtils";
+import { Json } from "../Response";
+
+export default class Meeting {
+    meetingId: string;
+    roomName: string;
+    roomUrl: string;
+    startDate: Date;
+    endDate: Date;
+    hostRoomUrl: string | null;
+    viewerRoomUrl: string | null;
+
+    constructor({ meetingId, roomName, roomUrl, startDate, endDate, hostRoomUrl, viewerRoomUrl }: Meeting) {
+        assertString(meetingId, "meetingId");
+        assertString(roomName, "roomName");
+        assertString(roomUrl, "roomUrl");
+
+        assertInstanceOf(startDate, Date, "startDate");
+        assertInstanceOf(endDate, Date, "endDate");
+
+        this.meetingId = meetingId;
+        this.roomName = roomName;
+        this.roomUrl = roomUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.hostRoomUrl = hostRoomUrl;
+        this.viewerRoomUrl = viewerRoomUrl;
+    }
+
+    static fromJson(data: Json): Meeting {
+        return new Meeting({
+            meetingId: extractString(data, "meetingId"),
+            roomName: extractString(data, "roomName"),
+            roomUrl: extractString(data, "roomUrl"),
+            startDate: extractDate(data, "startDate"),
+            endDate: extractDate(data, "endDate"),
+            hostRoomUrl: extractNullOrString(data, "hostRoomUrl"),
+            viewerRoomUrl: extractNullOrString(data, "viewerRoomUrl"),
+        });
+    }
+}

--- a/src/lib/api/models/Organization.ts
+++ b/src/lib/api/models/Organization.ts
@@ -1,0 +1,186 @@
+import { assertInstanceOf, assertString } from "../parameterAssertUtils";
+import { Json } from "../Response";
+
+import Account from "./Account";
+
+interface OrganizationPermissionAction {
+    isAllowed: boolean;
+    isSupported: boolean;
+}
+
+interface FullOrganizationPermissions {
+    images: {
+        logoImageUrl: {
+            set: OrganizationPermissionAction;
+            reset: OrganizationPermissionAction;
+        };
+        roomBackgroundImageUrl: {
+            set: OrganizationPermissionAction;
+            reset: OrganizationPermissionAction;
+        };
+        roomKnockPageBackgroundImageUrl: {
+            set: OrganizationPermissionAction;
+            reset: OrganizationPermissionAction;
+        };
+    };
+    invitations: {
+        add: OrganizationPermissionAction;
+        delete: OrganizationPermissionAction;
+        list: OrganizationPermissionAction;
+    };
+    roles: {
+        set: OrganizationPermissionAction;
+        remove: OrganizationPermissionAction;
+        removeSelf: OrganizationPermissionAction;
+        list: OrganizationPermissionAction;
+    };
+    users: {
+        signUpWithoutInvitation: OrganizationPermissionAction;
+    };
+    rooms: {
+        customize: OrganizationPermissionAction;
+        customizeSelf: OrganizationPermissionAction;
+        list: OrganizationPermissionAction;
+        lock: OrganizationPermissionAction;
+        unclaim: OrganizationPermissionAction;
+        unclaimSelf: OrganizationPermissionAction;
+    };
+    subscriptions: {
+        add: OrganizationPermissionAction;
+        list: OrganizationPermissionAction;
+        payLatestInvoice: OrganizationPermissionAction;
+        updatePlan: OrganizationPermissionAction;
+    };
+    browserExtension: {
+        install: OrganizationPermissionAction;
+    };
+}
+type OrganizationPermissions = Partial<FullOrganizationPermissions>;
+
+interface OrganizationLimits {
+    maxNumberOfInvitationsAndUsers: number | null;
+    maxNumberOfClaimedRooms: number | null;
+    maxRoomLimitPerOrganization: number | null;
+    trialMinutesLimit: number | null;
+    includedUnits: number | null;
+}
+interface OrganizationOnboardingSurvey {
+    name: string;
+    value: unknown;
+}
+
+export type OrganizationPreferences = Record<string, boolean | string | null | number>;
+
+export function hasValue(value: unknown): boolean {
+    return value !== null && value !== undefined;
+}
+
+function createOrganizationLimits(limits: Record<string, unknown> = {}): OrganizationLimits {
+    return {
+        maxNumberOfInvitationsAndUsers: hasValue(limits?.maxNumberOfInvitationsAndUsers)
+            ? Number(limits?.maxNumberOfInvitationsAndUsers)
+            : null,
+        maxNumberOfClaimedRooms: hasValue(limits?.maxNumberOfClaimedRooms)
+            ? Number(limits?.maxNumberOfClaimedRooms)
+            : null,
+        maxRoomLimitPerOrganization: hasValue(limits?.maxRoomLimitPerOrganization)
+            ? Number(limits?.maxRoomLimitPerOrganization)
+            : null,
+        trialMinutesLimit: hasValue(limits?.trialMinutesLimit) ? Number(limits?.trialMinutesLimit) : null,
+        includedUnits: hasValue(limits?.includedUnits) ? Number(limits?.includedUnits) : null,
+    };
+}
+
+export default class Organization {
+    static GLOBAL_ORGANIZATION_ID = "1";
+
+    organizationId: string;
+    organizationName: string;
+    subdomain: string;
+    permissions: OrganizationPermissions;
+    limits: OrganizationLimits;
+    account: Account | null;
+    logoImageUrl: string | null = null;
+    roomBackgroundImageUrl: string | null = null;
+    roomBackgroundThumbnailUrl: string | null = null;
+    roomKnockPageBackgroundImageUrl: string | null = null;
+    roomKnockPageBackgroundThumbnailUrl: string | null = null;
+    preferences: OrganizationPreferences | null = null;
+    onboardingSurvey: OrganizationOnboardingSurvey | null = null;
+    type: string | null = null;
+
+    constructor(properties: {
+        account: Account | null;
+        organizationId: string;
+        organizationName: string;
+        subdomain: string;
+        permissions: OrganizationPermissions;
+        limits: OrganizationLimits;
+        logoImageUrl: string | null;
+        roomBackgroundImageUrl: string | null;
+        roomBackgroundThumbnailUrl: string | null;
+        roomKnockPageBackgroundImageUrl: string | null;
+        roomKnockPageBackgroundThumbnailUrl: string | null;
+        preferences: OrganizationPreferences | null;
+        onboardingSurvey: OrganizationOnboardingSurvey | null;
+        type: string | null;
+    }) {
+        assertInstanceOf(properties, Object, "properties");
+        assertString(properties.organizationId, "organizationId");
+        assertString(properties.organizationName, "organizationName");
+        assertString(properties.subdomain, "subdomain");
+        assertInstanceOf(properties.permissions, Object, "permissions");
+        assertInstanceOf(properties.limits, Object, "limits");
+
+        this.organizationId = properties.organizationId;
+        this.organizationName = properties.organizationName;
+        this.subdomain = properties.subdomain;
+        this.permissions = properties.permissions;
+        this.limits = properties.limits;
+        this.account = properties.account ? new Account(properties.account) : null;
+        this.logoImageUrl = properties.logoImageUrl;
+        this.roomBackgroundImageUrl = properties.roomBackgroundImageUrl;
+        this.roomBackgroundThumbnailUrl = properties.roomBackgroundThumbnailUrl;
+        this.roomKnockPageBackgroundImageUrl = properties.roomKnockPageBackgroundImageUrl;
+        this.roomKnockPageBackgroundThumbnailUrl = properties.roomKnockPageBackgroundThumbnailUrl;
+        this.preferences = properties.preferences;
+        this.onboardingSurvey = properties.onboardingSurvey;
+        this.type = properties.type;
+    }
+
+    static fromJson(data: Json): Organization {
+        const parsedData = assertInstanceOf(data, Object, "data") as Record<string, unknown>;
+        const preferences = (parsedData?.preferences || {}) as OrganizationPreferences;
+        const onboardingSurvey = (parsedData?.onboardingSurvey || null) as OrganizationOnboardingSurvey;
+        const permissions = assertInstanceOf(parsedData.permissions, Object, "permissions") as OrganizationPreferences;
+
+        return new Organization({
+            organizationId: assertString(parsedData.organizationId, "organizationId"),
+            organizationName: assertString(parsedData.organizationName, "organizationName"),
+            subdomain: assertString(parsedData.subdomain, "subdomain"),
+            permissions,
+            limits: createOrganizationLimits(
+                assertInstanceOf(parsedData.limits, Object, "limits") as Record<string, unknown>
+            ),
+            account: parsedData.account ? Account.fromJson(parsedData.account as Record<string, unknown>) : null,
+            logoImageUrl: typeof parsedData.logoImageUrl === "string" ? parsedData.logoImageUrl : null,
+            roomBackgroundImageUrl:
+                typeof parsedData.roomBackgroundImageUrl === "string" ? parsedData.roomBackgroundImageUrl : null,
+            roomBackgroundThumbnailUrl:
+                typeof parsedData.roomBackgroundThumbnailUrl === "string"
+                    ? parsedData.roomBackgroundThumbnailUrl
+                    : null,
+            roomKnockPageBackgroundImageUrl:
+                typeof parsedData.roomKnockPageBackgroundImageUrl === "string"
+                    ? parsedData.roomKnockPageBackgroundImageUrl
+                    : null,
+            roomKnockPageBackgroundThumbnailUrl:
+                typeof parsedData.roomKnockPageBackgroundThumbnailUrl === "string"
+                    ? parsedData.roomKnockPageBackgroundThumbnailUrl
+                    : null,
+            preferences,
+            onboardingSurvey,
+            type: typeof parsedData.type === "string" ? parsedData.type : null,
+        });
+    }
+}

--- a/src/lib/api/models/Room.ts
+++ b/src/lib/api/models/Room.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import assert from "assert";
+
+export default class Room {
+    constructor(properties = {}) {
+        assert.ok(properties instanceof Object, "properties<object> must be empty or an object");
+
+        this.isClaimed = false;
+        this.isBanned = false;
+        this.isLocked = false;
+        this.knockPage = {
+            backgroundImageUrl: null,
+            backgroundThumbnailUrl: null,
+        };
+        this.logoUrl = null;
+        this.backgroundImageUrl = null;
+        this.backgroundThumbnailUrl = null;
+        this.type = null;
+        this.legacyRoomType = null;
+        this.mode = null;
+        this.product = null;
+        this.roomName = null;
+        this.theme = null;
+        this.preferences = {};
+        this.protectedPreferences = {};
+        this.publicProfile = null;
+
+        // Only allow existing property names to be modified
+        const validProperties = {};
+        Object.getOwnPropertyNames(properties).forEach((prop) => {
+            if (Object.getOwnPropertyNames(this).indexOf(prop) !== -1) {
+                validProperties[prop] = properties[prop];
+            }
+        });
+        if (properties.ownerId !== undefined) {
+            this.ownerId = properties.ownerId;
+        }
+        if (properties.meeting !== undefined) {
+            this.meeting = properties.meeting;
+        }
+
+        Object.assign(this, validProperties);
+    }
+}

--- a/src/lib/api/models/account/EmbeddedFreeTierStatus.ts
+++ b/src/lib/api/models/account/EmbeddedFreeTierStatus.ts
@@ -1,0 +1,34 @@
+import { assertBoolean, assertNumber, assertString } from "../../parameterAssertUtils";
+
+export default class EmbeddedFreeTierStatus {
+    isExhausted: boolean;
+    renewsAt: Date;
+    totalMinutesLimit: number;
+    totalMinutesUsed: number;
+
+    constructor({
+        isExhausted,
+        renewsAt,
+        totalMinutesLimit,
+        totalMinutesUsed,
+    }: {
+        isExhausted: boolean;
+        renewsAt: Date;
+        totalMinutesLimit: number;
+        totalMinutesUsed: number;
+    }) {
+        this.isExhausted = isExhausted;
+        this.renewsAt = renewsAt;
+        this.totalMinutesLimit = totalMinutesLimit;
+        this.totalMinutesUsed = totalMinutesUsed;
+    }
+
+    static fromJson(data: Record<string, unknown>): EmbeddedFreeTierStatus {
+        return new EmbeddedFreeTierStatus({
+            isExhausted: assertBoolean(data.isExhausted, "isExhausted"),
+            renewsAt: new Date(assertString(data.renewsAt, "renewsAt")),
+            totalMinutesLimit: assertNumber(data.totalMinutesLimit, "totalMinutesLimit"),
+            totalMinutesUsed: assertNumber(data.totalMinutesUsed, "totalMinutesUsed"),
+        });
+    }
+}

--- a/src/lib/api/models/tests/Account.spec.ts
+++ b/src/lib/api/models/tests/Account.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from "chai";
-
 import Account from "../Account";
 import EmbeddedFreeTierStatus from "../account/EmbeddedFreeTierStatus";
 
@@ -18,6 +16,15 @@ describe("Account", () => {
                     totalMinutesLimit: 1000,
                     totalMinutesUsed: 700,
                 };
+                const embeddedFreeTierStatusFromJson = EmbeddedFreeTierStatus.fromJson(embeddedFreeTierStatus);
+                const expectedAccount = new Account({
+                    basePlanId,
+                    isDeactivated,
+                    isOnTrial,
+                    onTrialUntil: new Date(onTrialUntil),
+                    trialStatus,
+                    embeddedFreeTierStatus: embeddedFreeTierStatusFromJson,
+                });
 
                 const result = Account.fromJson({
                     basePlanId,
@@ -28,19 +35,15 @@ describe("Account", () => {
                     embeddedFreeTierStatus,
                 });
 
-                // @ts-ignore
-                expect(result)
-                    .to.be.an.instanceOf(Account)
-                    .and.to.deep.equal(
-                        new Account({
-                            basePlanId,
-                            isDeactivated,
-                            isOnTrial,
-                            onTrialUntil: new Date(onTrialUntil),
-                            trialStatus,
-                            embeddedFreeTierStatus: EmbeddedFreeTierStatus.fromJson(embeddedFreeTierStatus),
-                        })
-                    );
+                expect(result).toBeInstanceOf(Account);
+                expect(result.basePlanId).toEqual(expectedAccount.basePlanId);
+                expect(result.isDeactivated).toEqual(expectedAccount.isDeactivated);
+                expect(result.isOnTrial).toEqual(expectedAccount.isOnTrial);
+                expect(result.onTrialUntil).toEqual(expectedAccount.onTrialUntil);
+                expect(result.trialStatus).toEqual(expectedAccount.trialStatus);
+                expect(JSON.stringify(result.embeddedFreeTierStatus)).toEqual(
+                    JSON.stringify(embeddedFreeTierStatusFromJson)
+                );
             });
         });
 
@@ -51,6 +54,14 @@ describe("Account", () => {
                 const isOnTrial = true;
                 const onTrialUntil = "09-02-2022";
                 const trialStatus = "some-status";
+                const expectedAccount = new Account({
+                    basePlanId,
+                    isDeactivated,
+                    isOnTrial,
+                    onTrialUntil: new Date(onTrialUntil),
+                    trialStatus,
+                    embeddedFreeTierStatus: null,
+                });
 
                 const result = Account.fromJson({
                     basePlanId,
@@ -61,18 +72,13 @@ describe("Account", () => {
                 });
 
                 // @ts-ignore
-                expect(result)
-                    .to.be.an.instanceOf(Account)
-                    .and.to.deep.equal(
-                        new Account({
-                            basePlanId,
-                            isDeactivated,
-                            isOnTrial,
-                            onTrialUntil: new Date(onTrialUntil),
-                            trialStatus,
-                            embeddedFreeTierStatus: null,
-                        })
-                    );
+                expect(result).toBeInstanceOf(Account);
+                expect(result.basePlanId).toEqual(expectedAccount.basePlanId);
+                expect(result.isDeactivated).toEqual(expectedAccount.isDeactivated);
+                expect(result.isOnTrial).toEqual(expectedAccount.isOnTrial);
+                expect(result.onTrialUntil).toEqual(expectedAccount.onTrialUntil);
+                expect(result.trialStatus).toEqual(expectedAccount.trialStatus);
+                expect(result.embeddedFreeTierStatus).toEqual(null);
             });
         });
 
@@ -88,6 +94,15 @@ describe("Account", () => {
                     totalMinutesLimit: 1000,
                     totalMinutesUsed: 700,
                 };
+                const embeddedFreeTierStatusFromJson = EmbeddedFreeTierStatus.fromJson(embeddedFreeTierStatus);
+                const expectedAccount = new Account({
+                    basePlanId: null,
+                    isDeactivated,
+                    isOnTrial,
+                    onTrialUntil: new Date(onTrialUntil),
+                    trialStatus,
+                    embeddedFreeTierStatus: embeddedFreeTierStatusFromJson,
+                });
 
                 const result = Account.fromJson({
                     embeddedFreeTierStatus,
@@ -98,18 +113,15 @@ describe("Account", () => {
                 });
 
                 // @ts-ignore
-                expect(result)
-                    .to.be.an.instanceOf(Account)
-                    .and.to.deep.equal(
-                        new Account({
-                            basePlanId: null,
-                            isDeactivated,
-                            isOnTrial,
-                            onTrialUntil: new Date(onTrialUntil),
-                            trialStatus,
-                            embeddedFreeTierStatus: EmbeddedFreeTierStatus.fromJson(embeddedFreeTierStatus),
-                        })
-                    );
+                expect(result).toBeInstanceOf(Account);
+                expect(result.basePlanId).toEqual(expectedAccount.basePlanId);
+                expect(result.isDeactivated).toEqual(expectedAccount.isDeactivated);
+                expect(result.isOnTrial).toEqual(expectedAccount.isOnTrial);
+                expect(result.onTrialUntil).toEqual(expectedAccount.onTrialUntil);
+                expect(result.trialStatus).toEqual(expectedAccount.trialStatus);
+                expect(JSON.stringify(result.embeddedFreeTierStatus)).toEqual(
+                    JSON.stringify(embeddedFreeTierStatusFromJson)
+                );
             });
         });
     });

--- a/src/lib/api/models/tests/Account.spec.ts
+++ b/src/lib/api/models/tests/Account.spec.ts
@@ -1,0 +1,116 @@
+import { expect } from "chai";
+
+import Account from "../Account";
+import EmbeddedFreeTierStatus from "../account/EmbeddedFreeTierStatus";
+
+describe("Account", () => {
+    describe("fromJson", () => {
+        describe("when embeddedFreeTierStatus is provided", () => {
+            it("should return an instance of Account with the right values", () => {
+                const basePlanId = "some-base-plan-id";
+                const isDeactivated = false;
+                const isOnTrial = true;
+                const onTrialUntil = "09-02-2022";
+                const trialStatus = "some-status";
+                const embeddedFreeTierStatus = {
+                    isExhausted: false,
+                    renewsAt: "23-02-2022",
+                    totalMinutesLimit: 1000,
+                    totalMinutesUsed: 700,
+                };
+
+                const result = Account.fromJson({
+                    basePlanId,
+                    isDeactivated,
+                    isOnTrial,
+                    onTrialUntil,
+                    trialStatus,
+                    embeddedFreeTierStatus,
+                });
+
+                // @ts-ignore
+                expect(result)
+                    .to.be.an.instanceOf(Account)
+                    .and.to.deep.equal(
+                        new Account({
+                            basePlanId,
+                            isDeactivated,
+                            isOnTrial,
+                            onTrialUntil: new Date(onTrialUntil),
+                            trialStatus,
+                            embeddedFreeTierStatus: EmbeddedFreeTierStatus.fromJson(embeddedFreeTierStatus),
+                        })
+                    );
+            });
+        });
+
+        describe("when embeddedFreeTierStatus is not provided", () => {
+            it("should return an instance of Account with embeddedFreeTierStatus as null", () => {
+                const basePlanId = "some-base-plan-id";
+                const isDeactivated = false;
+                const isOnTrial = true;
+                const onTrialUntil = "09-02-2022";
+                const trialStatus = "some-status";
+
+                const result = Account.fromJson({
+                    basePlanId,
+                    isDeactivated,
+                    isOnTrial,
+                    onTrialUntil,
+                    trialStatus,
+                });
+
+                // @ts-ignore
+                expect(result)
+                    .to.be.an.instanceOf(Account)
+                    .and.to.deep.equal(
+                        new Account({
+                            basePlanId,
+                            isDeactivated,
+                            isOnTrial,
+                            onTrialUntil: new Date(onTrialUntil),
+                            trialStatus,
+                            embeddedFreeTierStatus: null,
+                        })
+                    );
+            });
+        });
+
+        describe("when basePlanId is not provided", () => {
+            it("should return an Account with basePlanId set to null", () => {
+                const isDeactivated = false;
+                const isOnTrial = true;
+                const onTrialUntil = "09-02-2022";
+                const trialStatus = "some-status";
+                const embeddedFreeTierStatus = {
+                    isExhausted: false,
+                    renewsAt: "23-02-2022",
+                    totalMinutesLimit: 1000,
+                    totalMinutesUsed: 700,
+                };
+
+                const result = Account.fromJson({
+                    embeddedFreeTierStatus,
+                    isDeactivated,
+                    isOnTrial,
+                    onTrialUntil,
+                    trialStatus,
+                });
+
+                // @ts-ignore
+                expect(result)
+                    .to.be.an.instanceOf(Account)
+                    .and.to.deep.equal(
+                        new Account({
+                            basePlanId: null,
+                            isDeactivated,
+                            isOnTrial,
+                            onTrialUntil: new Date(onTrialUntil),
+                            trialStatus,
+                            embeddedFreeTierStatus: EmbeddedFreeTierStatus.fromJson(embeddedFreeTierStatus),
+                        })
+                    );
+            });
+        });
+    });
+});

--- a/src/lib/api/models/tests/Organization.spec.ts
+++ b/src/lib/api/models/tests/Organization.spec.ts
@@ -1,0 +1,159 @@
+import Organization, { hasValue } from "../Organization";
+import Account from "../Account";
+import { expect } from "chai";
+
+const defaultOrganization = {};
+
+describe("Organization", () => {
+    const organizationId = "12";
+    const organizationName = "some-name";
+    const subdomain = "someOrganization";
+    const account = null;
+    const limits = {
+        maxNumberOfClaimedRooms: null,
+        maxNumberOfInvitationsAndUsers: null,
+        maxRoomLimitPerOrganization: null,
+        trialMinutesLimit: null,
+        includedUnits: null,
+    };
+    const logoImageUrl = "some-logoImageUrl";
+    const roomBackgroundImageUrl = "some-roomBackgroundImageUrl";
+    const roomBackgroundThumbnailUrl = "some-roomBackgroundThumbnailUrl";
+    const roomKnockPageBackgroundImageUrl = "some-roomKnockPageBackgroundImageUrl";
+    const roomKnockPageBackgroundThumbnailUrl = "some-roomKnockPageBackgroundThumbnailUrl";
+    const preferences = {};
+    const onboardingSurvey = null;
+    const type = "public";
+
+    describe("constructor", () => {
+        it("should return a correctly extended organization object", () => {
+            const permissions = {
+                cloudRecording: {
+                    setConfig: { isAllowed: true, isSupported: true },
+                },
+                images: {
+                    logoImageUrl: {
+                        set: { isAllowed: true, isSupported: true },
+                        reset: { isAllowed: true, isSupported: true },
+                    },
+                    roomBackgroundImageUrl: {
+                        set: { isAllowed: true, isSupported: true },
+                        reset: { isAllowed: true, isSupported: true },
+                    },
+                    roomKnockPageBackgroundImageUrl: {
+                        set: { isAllowed: true, isSupported: true },
+                        reset: { isAllowed: true, isSupported: true },
+                    },
+                },
+                invitations: {
+                    add: { isAllowed: true, isSupported: true },
+                    delete: { isAllowed: true, isSupported: true },
+                    list: { isAllowed: true, isSupported: true },
+                },
+                roles: {
+                    set: { isAllowed: true, isSupported: true },
+                    remove: { isAllowed: true, isSupported: true },
+                    removeSelf: { isAllowed: true, isSupported: true },
+                    list: { isAllowed: true, isSupported: true },
+                },
+                users: {
+                    signUpWithoutInvitation: { isAllowed: true, isSupported: true },
+                },
+            };
+            const properties = {
+                organizationId,
+                organizationName,
+                subdomain,
+                account,
+                permissions,
+                limits,
+                logoImageUrl,
+                roomBackgroundImageUrl,
+                roomBackgroundThumbnailUrl,
+                roomKnockPageBackgroundImageUrl,
+                roomKnockPageBackgroundThumbnailUrl,
+                preferences,
+                onboardingSurvey,
+                type,
+            };
+            const organization = new Organization(properties);
+            const expectedObj = Object.assign({}, defaultOrganization, properties);
+
+            expect(organization).deep.equal(expectedObj);
+        });
+
+        it("should instantiate an Account object if account information is provided", () => {
+            const permissions = {
+                rooms: {
+                    changeTypeToPersonal: { isAllowed: true, isSupported: true },
+                    changeTypeToPersonalXl: { isAllowed: true, isSupported: true },
+                    customize: { isAllowed: true, isSupported: true },
+                    customizeSelf: { isAllowed: true, isSupported: true },
+                    list: { isAllowed: true, isSupported: true },
+                    lock: { isAllowed: true, isSupported: true },
+                    unclaim: { isAllowed: true, isSupported: true },
+                    unclaimSelf: { isAllowed: true, isSupported: true },
+                },
+                subscriptions: {
+                    add: { isAllowed: true, isSupported: true },
+                    list: { isAllowed: true, isSupported: true },
+                    payLatestInvoice: { isAllowed: true, isSupported: true },
+                    updatePlan: { isAllowed: true, isSupported: true },
+                },
+                browserExtension: {
+                    install: { isAllowed: true, isSupported: true },
+                },
+            };
+            const properties = {
+                account: {
+                    basePlanId: "some-base-plan-id",
+                    isDeactivated: false,
+                    onTrialUntil: null,
+                    isOnTrial: false,
+                    trialStatus: "some-status",
+                    embeddedFreeTierStatus: null,
+                },
+                organizationId,
+                organizationName,
+                subdomain,
+                permissions,
+                limits,
+                logoImageUrl,
+                roomBackgroundImageUrl,
+                roomBackgroundThumbnailUrl,
+                roomKnockPageBackgroundImageUrl,
+                roomKnockPageBackgroundThumbnailUrl,
+                preferences,
+                onboardingSurvey,
+                type,
+            };
+            const organization = new Organization(properties);
+
+            expect(organization.account).to.be.instanceOf(Account);
+        });
+    });
+
+    describe("GLOBAL_ORGANIZATION_ID", () => {
+        it("should be 1", () => {
+            expect(Organization.GLOBAL_ORGANIZATION_ID).to.equal("1");
+        });
+    });
+
+    describe("hasValue", () => {
+        it("should return true when value is 0", () => {
+            expect(hasValue(0)).to.equal(true);
+        });
+
+        it(`should return true when value is "0"`, () => {
+            expect(hasValue("0")).to.equal(true);
+        });
+
+        it("should return false when value is undefined", () => {
+            expect(hasValue(undefined)).to.equal(false);
+        });
+
+        it("should return false when value is null", () => {
+            expect(hasValue(null)).to.equal(false);
+        });
+    });
+});

--- a/src/lib/api/models/tests/Organization.spec.ts
+++ b/src/lib/api/models/tests/Organization.spec.ts
@@ -1,6 +1,5 @@
 import Organization, { hasValue } from "../Organization";
 import Account from "../Account";
-import { expect } from "chai";
 
 const defaultOrganization = {};
 
@@ -79,81 +78,84 @@ describe("Organization", () => {
             const organization = new Organization(properties);
             const expectedObj = Object.assign({}, defaultOrganization, properties);
 
-            expect(organization).deep.equal(expectedObj);
+            expect(organization).toEqual(expectedObj);
         });
 
-        it("should instantiate an Account object if account information is provided", () => {
-            const permissions = {
-                rooms: {
-                    changeTypeToPersonal: { isAllowed: true, isSupported: true },
-                    changeTypeToPersonalXl: { isAllowed: true, isSupported: true },
-                    customize: { isAllowed: true, isSupported: true },
-                    customizeSelf: { isAllowed: true, isSupported: true },
-                    list: { isAllowed: true, isSupported: true },
-                    lock: { isAllowed: true, isSupported: true },
-                    unclaim: { isAllowed: true, isSupported: true },
-                    unclaimSelf: { isAllowed: true, isSupported: true },
-                },
-                subscriptions: {
-                    add: { isAllowed: true, isSupported: true },
-                    list: { isAllowed: true, isSupported: true },
-                    payLatestInvoice: { isAllowed: true, isSupported: true },
-                    updatePlan: { isAllowed: true, isSupported: true },
-                },
-                browserExtension: {
-                    install: { isAllowed: true, isSupported: true },
-                },
-            };
-            const properties = {
-                account: {
-                    basePlanId: "some-base-plan-id",
-                    isDeactivated: false,
-                    onTrialUntil: null,
-                    isOnTrial: false,
-                    trialStatus: "some-status",
-                    embeddedFreeTierStatus: null,
-                },
-                organizationId,
-                organizationName,
-                subdomain,
-                permissions,
-                limits,
-                logoImageUrl,
-                roomBackgroundImageUrl,
-                roomBackgroundThumbnailUrl,
-                roomKnockPageBackgroundImageUrl,
-                roomKnockPageBackgroundThumbnailUrl,
-                preferences,
-                onboardingSurvey,
-                type,
-            };
-            const organization = new Organization(properties);
+        it(
+            "should instantiate an Account object if account information is provided",
+            () => {
+                const permissions = {
+                    rooms: {
+                        changeTypeToPersonal: { isAllowed: true, isSupported: true },
+                        changeTypeToPersonalXl: { isAllowed: true, isSupported: true },
+                        customize: { isAllowed: true, isSupported: true },
+                        customizeSelf: { isAllowed: true, isSupported: true },
+                        list: { isAllowed: true, isSupported: true },
+                        lock: { isAllowed: true, isSupported: true },
+                        unclaim: { isAllowed: true, isSupported: true },
+                        unclaimSelf: { isAllowed: true, isSupported: true },
+                    },
+                    subscriptions: {
+                        add: { isAllowed: true, isSupported: true },
+                        list: { isAllowed: true, isSupported: true },
+                        payLatestInvoice: { isAllowed: true, isSupported: true },
+                        updatePlan: { isAllowed: true, isSupported: true },
+                    },
+                    browserExtension: {
+                        install: { isAllowed: true, isSupported: true },
+                    },
+                };
+                const properties = {
+                    account: {
+                        basePlanId: "some-base-plan-id",
+                        isDeactivated: false,
+                        onTrialUntil: null,
+                        isOnTrial: false,
+                        trialStatus: "some-status",
+                        embeddedFreeTierStatus: null,
+                    },
+                    organizationId,
+                    organizationName,
+                    subdomain,
+                    permissions,
+                    limits,
+                    logoImageUrl,
+                    roomBackgroundImageUrl,
+                    roomBackgroundThumbnailUrl,
+                    roomKnockPageBackgroundImageUrl,
+                    roomKnockPageBackgroundThumbnailUrl,
+                    preferences,
+                    onboardingSurvey,
+                    type,
+                };
+                const organization = new Organization(properties);
 
-            expect(organization.account).to.be.instanceOf(Account);
-        });
+                expect(organization.account).toBeInstanceOf(Account);
+            }
+        );
     });
 
     describe("GLOBAL_ORGANIZATION_ID", () => {
         it("should be 1", () => {
-            expect(Organization.GLOBAL_ORGANIZATION_ID).to.equal("1");
+            expect(Organization.GLOBAL_ORGANIZATION_ID).toBe("1");
         });
     });
 
     describe("hasValue", () => {
         it("should return true when value is 0", () => {
-            expect(hasValue(0)).to.equal(true);
+            expect(hasValue(0)).toBe(true);
         });
 
         it(`should return true when value is "0"`, () => {
-            expect(hasValue("0")).to.equal(true);
+            expect(hasValue("0")).toBe(true);
         });
 
         it("should return false when value is undefined", () => {
-            expect(hasValue(undefined)).to.equal(false);
+            expect(hasValue(undefined)).toBe(false);
         });
 
         it("should return false when value is null", () => {
-            expect(hasValue(null)).to.equal(false);
+            expect(hasValue(null)).toBe(false);
         });
     });
 });

--- a/src/lib/api/models/tests/Room.spec.ts
+++ b/src/lib/api/models/tests/Room.spec.ts
@@ -28,7 +28,7 @@ describe("Room", () => {
     it("should return the default room if no room is passed in", () => {
         const room = new Room();
 
-        expect(room).deep.equal(defaultRoom);
+        expect(room).toEqual(defaultRoom);
     });
 
     it("should return a correctly extended room object", () => {
@@ -39,30 +39,36 @@ describe("Room", () => {
         const room = new Room(extendedObj);
         const expectedObj = Object.assign({}, defaultRoom, extendedObj);
 
-        expect(room).deep.equal(expectedObj);
+        expect(room).toEqual(expectedObj);
     });
 
-    it("should return a correctly extended room object without the invalid property", () => {
-        const room = new Room({
-            isClaimed: true,
-            someProperty: "someValue",
-        });
-        const expectedObj = Object.assign({}, defaultRoom, { isClaimed: true });
+    it(
+        "should return a correctly extended room object without the invalid property",
+        () => {
+            const room = new Room({
+                isClaimed: true,
+                someProperty: "someValue",
+            });
+            const expectedObj = Object.assign({}, defaultRoom, { isClaimed: true });
 
-        expect(room).deep.equal(expectedObj);
-    });
+            expect(room).toEqual(expectedObj);
+        }
+    );
 
-    it("should return the room with the meeting if the meeting is passed in", () => {
-        const meeting = new Meeting({
-            meetingId: "123",
-            startDate: new Date(),
-            endDate: new Date(),
-            roomName: "/some-room-name",
-            roomUrl: "some-room-url",
-        });
+    it(
+        "should return the room with the meeting if the meeting is passed in",
+        () => {
+            const meeting = new Meeting({
+                meetingId: "123",
+                startDate: new Date(),
+                endDate: new Date(),
+                roomName: "/some-room-name",
+                roomUrl: "some-room-url",
+            });
 
-        const room = new Room({ meeting });
+            const room = new Room({ meeting });
 
-        expect(room).deep.equal({ ...defaultRoom, meeting });
-    });
+            expect(room).toEqual({ ...defaultRoom, meeting });
+        }
+    );
 });

--- a/src/lib/api/models/tests/Room.spec.ts
+++ b/src/lib/api/models/tests/Room.spec.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import Meeting from "../Meeting";
+import Room from "../Room";
+
+const defaultRoom = {
+    isClaimed: false,
+    isBanned: false,
+    isLocked: false,
+    knockPage: {
+        backgroundImageUrl: null,
+        backgroundThumbnailUrl: null,
+    },
+    logoUrl: null,
+    backgroundImageUrl: null,
+    backgroundThumbnailUrl: null,
+    type: null,
+    legacyRoomType: null,
+    mode: null,
+    product: null,
+    roomName: null,
+    theme: null,
+    preferences: {},
+    protectedPreferences: {},
+    publicProfile: null,
+};
+
+describe("Room", () => {
+    it("should return the default room if no room is passed in", () => {
+        const room = new Room();
+
+        expect(room).deep.equal(defaultRoom);
+    });
+
+    it("should return a correctly extended room object", () => {
+        const extendedObj = {
+            isClaimed: true,
+            roomName: "/some-room-name",
+        };
+        const room = new Room(extendedObj);
+        const expectedObj = Object.assign({}, defaultRoom, extendedObj);
+
+        expect(room).deep.equal(expectedObj);
+    });
+
+    it("should return a correctly extended room object without the invalid property", () => {
+        const room = new Room({
+            isClaimed: true,
+            someProperty: "someValue",
+        });
+        const expectedObj = Object.assign({}, defaultRoom, { isClaimed: true });
+
+        expect(room).deep.equal(expectedObj);
+    });
+
+    it("should return the room with the meeting if the meeting is passed in", () => {
+        const meeting = new Meeting({
+            meetingId: "123",
+            startDate: new Date(),
+            endDate: new Date(),
+            roomName: "/some-room-name",
+            roomUrl: "some-room-url",
+        });
+
+        const room = new Room({ meeting });
+
+        expect(room).deep.equal({ ...defaultRoom, meeting });
+    });
+});

--- a/src/lib/api/modules/AbstractStore.ts
+++ b/src/lib/api/modules/AbstractStore.ts
@@ -1,0 +1,18 @@
+/*
+ * Abstract class which all credential stores needs to inherit to
+ * be usable with CredentialsService
+ */
+
+import { Json } from "../Response";
+
+export default interface AbstractStore {
+    /*
+     * Get value
+     */
+    loadOrDefault(defaultValue: Json): Promise<Json>;
+
+    /*
+     * Set value
+     */
+    save(value: Json): Promise<void>;
+}

--- a/src/lib/api/modules/ChromeStorageStore.ts
+++ b/src/lib/api/modules/ChromeStorageStore.ts
@@ -1,0 +1,44 @@
+/**
+ * Utility to handle storing data in chrome.storage
+ */
+import { Json } from "../Response";
+import AbstractStore from "./AbstractStore";
+
+export default class ChromeStorageStore implements AbstractStore {
+    _key: string;
+    _chromeStorage: chrome.storage.StorageArea;
+
+    constructor(key: string, chromeStorage: chrome.storage.StorageArea) {
+        this._key = key;
+        this._chromeStorage = chromeStorage;
+    }
+
+    /**
+     * Returns the stored value for this store, or a default if not available.
+     *
+     * @param {(Object|Array.|string|number)} [defaultValue] - Value returned if the object can't be retrieved.
+     * @return {?(Object|Array.|string|number)} Value stored, or defaultValue if not available.
+     */
+    loadOrDefault(defaultValue: Json): Promise<Json> {
+        return new Promise((resolve) => {
+            this._chromeStorage.get(this._key, (result) => {
+                const unknownResult: Record<string, Json> = result;
+                resolve(unknownResult[this._key] || defaultValue);
+            });
+        });
+    }
+
+    /**
+     * Change the value stored for this key.
+     *
+     * @param {(Object|Array.|string|number)} [value] - New value, will replace any previously stored.
+     * @return {Promise<void>}
+     */
+    save(value: Json): Promise<void> {
+        return new Promise((resolve) => {
+            this._chromeStorage.set({ [this._key]: value }, () => {
+                resolve();
+            });
+        });
+    }
+}

--- a/src/lib/api/modules/LocalStorageStore.ts
+++ b/src/lib/api/modules/LocalStorageStore.ts
@@ -1,0 +1,57 @@
+import { assertString, assertTruthy } from "../parameterAssertUtils";
+import { Json } from "../Response";
+import AbstractStore from "./AbstractStore";
+
+/**
+ * Utility to ease handling localStorage.
+ */
+export default class LocalStorageStore implements AbstractStore {
+    _key: string;
+    _localStorage: Storage;
+
+    constructor(key: string, localStorage: Storage) {
+        assertTruthy(localStorage, "localStorage");
+        this._key = assertString(key, "key");
+        this._localStorage = localStorage;
+    }
+
+    /**
+     * Returns the stored value for this store, or a default if not available.
+     *
+     * @param {(Object|Array.|string|number)} [defaultValue] - Value returned if the object can't be retrieved.
+     * @return {?(Object|Array.|string|number)} Value stored, or defaultValue if not available.
+     */
+    loadOrDefault(defaultValue: Json): Promise<Json> {
+        try {
+            const value = this._localStorage.getItem(this._key);
+            if (value) {
+                try {
+                    return Promise.resolve(JSON.parse(value));
+                } catch (e) {
+                    /* NOOP */
+                }
+            }
+            return Promise.resolve(defaultValue);
+        } catch (e) {
+            // Cookies are blocked
+            console.warn("Error getting access to storage. Are cookies blocked?", e); // eslint-disable-line no-console
+            return Promise.resolve(defaultValue);
+        }
+    }
+
+    /**
+     * Change the value stored for this key.
+     *
+     * @param {(Object|Array.|string|number)} [value] - New value, will replace any previously stored.
+     */
+    save(value: Json): Promise<void> {
+        try {
+            this._localStorage.setItem(this._key, JSON.stringify(value));
+            return Promise.resolve();
+        } catch (e) {
+            /* NOOP, cookies are blocked */
+            console.warn("Error getting access to storage. Are cookies blocked?", e); // eslint-disable-line no-console
+            return Promise.reject(e);
+        }
+    }
+}

--- a/src/lib/api/modules/tests/ChromeStorageStore.spec.ts
+++ b/src/lib/api/modules/tests/ChromeStorageStore.spec.ts
@@ -1,0 +1,75 @@
+import sinon from "sinon";
+import ChromeStorageStore from "../ChromeStorageStore";
+import { expect } from "chai";
+
+describe("ChromeStorageStore", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let chromeStorage: any;
+    const storeName = "myStore1";
+    let credentialsStore: ChromeStorageStore;
+
+    beforeEach(() => {
+        chromeStorage = sinon.stub({
+            get() {
+                return {};
+            },
+
+            set() {
+                // Do nothing
+            },
+        });
+
+        credentialsStore = new ChromeStorageStore(storeName, chromeStorage);
+    });
+
+    describe("loadOrDefault", () => {
+        it("should resolve with the stored object", async () => {
+            const savedValue = { mrT: "I pitty the fool" };
+            chromeStorage.get.withArgs(storeName).callsArgWith(1, { [storeName]: savedValue });
+
+            const result = await credentialsStore.loadOrDefault({});
+
+            expect(result).to.eql(savedValue);
+        });
+
+        it("should resolve with the default value if a stored object cannot be retrieved", async () => {
+            const defaultValue = { mrT: "I pitty the fool" };
+            chromeStorage.get.withArgs(storeName).callsArgWith(1, {});
+
+            const result = await credentialsStore.loadOrDefault(defaultValue);
+
+            expect(result).to.eql(defaultValue);
+        });
+
+        it("should resolve with the default value if no object has been stored", async () => {
+            const defaultValue = { mrT: "I pitty the fool" };
+            chromeStorage.get.withArgs(storeName).callsArgWith(1, {});
+
+            const result = await credentialsStore.loadOrDefault(defaultValue);
+
+            expect(result).to.eql(defaultValue);
+        });
+    });
+
+    describe("save", () => {
+        it("should save the object to local storage", () => {
+            const savedValue = { mrT: "I pitty the fool" };
+            chromeStorage.set.withArgs({ [storeName]: savedValue }).callsArgWith(1, null);
+
+            const promise = credentialsStore.save(savedValue);
+
+            return promise.then(() => {
+                expect(chromeStorage.set).to.have.be.calledWith({ [storeName]: savedValue });
+            });
+        });
+
+        it("should return undefined", async () => {
+            const savedValue = { mrT: "I pitty the fool" };
+            chromeStorage.set.withArgs({ [storeName]: savedValue }).callsArgWith(1, null);
+
+            const result = await credentialsStore.save(savedValue);
+
+            expect(result).to.eql(undefined);
+        });
+    });
+});

--- a/src/lib/api/modules/tests/LocalStorageStore.spec.ts
+++ b/src/lib/api/modules/tests/LocalStorageStore.spec.ts
@@ -1,0 +1,90 @@
+import sinon from "sinon";
+import LocalStorageStore from "../LocalStorageStore";
+import { itShouldThrowIfInvalid } from "../../test/helpers";
+import { expect } from "chai";
+
+class DummyStore implements Storage {
+    [name: string]: unknown;
+    length: number;
+
+    constructor() {
+        this.length = 0;
+    }
+    clear(): void {
+        throw new Error("Method not implemented.");
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getItem(_key: string): string | null {
+        return "{}";
+    }
+    key(): string | null {
+        throw new Error("Method not implemented.");
+    }
+    removeItem(): void {
+        throw new Error("Method not implemented.");
+    }
+    setItem(): void {
+        // NOP
+    }
+}
+
+describe("LocalStorageStore", () => {
+    const storeName = "myStore";
+    let credentialsStore: LocalStorageStore;
+    let localStorage: sinon.SinonStubbedInstance<DummyStore>;
+
+    beforeEach(() => {
+        localStorage = sinon.createStubInstance(DummyStore);
+
+        credentialsStore = new LocalStorageStore(storeName, localStorage);
+    });
+
+    describe("constructor", () => {
+        //@ts-expect-error
+        itShouldThrowIfInvalid("key", () => new LocalStorageStore(undefined, localStorage));
+        //@ts-expect-error
+        itShouldThrowIfInvalid("localStorage", () => new LocalStorageStore(storeName, undefined));
+    });
+
+    describe("loadOrDefault", () => {
+        it("should resolve with the stored object if available", async () => {
+            const savedValue = { mrT: "I pitty the fool" };
+            localStorage.getItem.withArgs(storeName).returns(JSON.stringify(savedValue));
+
+            const result = await credentialsStore.loadOrDefault({});
+
+            expect(result).to.eql(savedValue);
+        });
+
+        it("should resolve with the default value if the stored object cannot be retrieved", async () => {
+            const defaultValue = { mrT: "I pitty the fool" };
+            localStorage.getItem.withArgs(storeName).returns("This is not valid json");
+
+            const result = await credentialsStore.loadOrDefault(defaultValue);
+
+            expect(result).to.eql(defaultValue);
+        });
+
+        it("should resolve with the default value if no object has been stored", async () => {
+            const defaultValue = { mrT: "I pitty the fool" };
+            localStorage.getItem.returns(null);
+
+            const result = await credentialsStore.loadOrDefault(defaultValue);
+
+            expect(result).to.eql(defaultValue);
+        });
+    });
+
+    describe("save", () => {
+        it("should save the object to local storage", () => {
+            const savedValue = { mrT: "I pitty the fool" };
+            const expectedValue = JSON.stringify(savedValue);
+
+            const promise = credentialsStore.save(savedValue);
+
+            return promise.then(() => {
+                expect(localStorage.setItem).to.have.be.calledWithExactly(storeName, expectedValue);
+            });
+        });
+    });
+});

--- a/src/lib/api/modules/tests/__mocks__/storage.ts
+++ b/src/lib/api/modules/tests/__mocks__/storage.ts
@@ -1,0 +1,24 @@
+export default class DummyStore implements Storage {
+    [name: string]: unknown;
+    length: number;
+
+    constructor() {
+        this.length = 0;
+    }
+    clear(): void {
+        throw new Error("Method not implemented.");
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getItem(_key: string): string | null {
+        return "{}";
+    }
+    key(): string | null {
+        throw new Error("Method not implemented.");
+    }
+    removeItem(): void {
+        throw new Error("Method not implemented.");
+    }
+    setItem(): void {
+        // NOP
+    }
+}

--- a/src/lib/api/organizationService/index.ts
+++ b/src/lib/api/organizationService/index.ts
@@ -1,0 +1,284 @@
+import assert from "assert";
+import Organization, { OrganizationPreferences } from "../models/Organization";
+import {
+    assertInstanceOf,
+    assertTruthy,
+    assertString,
+    assertArray,
+    assertNullOrString,
+    assertRecord,
+} from "../parameterAssertUtils";
+import ApiClient from "../ApiClient";
+import Response from "../Response";
+import { extractArray, extractString } from "../extractUtils";
+import { ConsentGrantRequest } from "../types";
+
+export default class OrganizationService {
+    _apiClient: ApiClient;
+
+    constructor({ apiClient }: { apiClient: ApiClient }) {
+        // apiClient is added since it will be used eventually or rather soon.
+        // this is to avoid the api to be broken again
+        this._apiClient = assertInstanceOf(apiClient, ApiClient);
+    }
+
+    /**
+     * Creates an organization.
+     */
+    createOrganization({
+        organizationName,
+        subdomain,
+        owner,
+    }: {
+        organizationName: string;
+        subdomain: string;
+        owner:
+            | {
+                  email: string;
+                  displayName: string;
+                  verificationCode: string;
+                  consents?: ReadonlyArray<ConsentGrantRequest>;
+              }
+            | {
+                  idToken: string;
+                  displayName: string;
+                  consents?: ReadonlyArray<ConsentGrantRequest>;
+              };
+    }): Promise<string> {
+        const { displayName, consents } = owner || {};
+        const email =
+            "email" in owner
+                ? {
+                      value: owner.email,
+                      verificationCode: assertString(owner.verificationCode, "owner.verificationCode"),
+                  }
+                : null;
+        const idToken = "idToken" in owner ? owner.idToken : null;
+        assertString(subdomain, "subdomain");
+        assertString(organizationName, "organizationName");
+        assertString(displayName, "owner.displayName");
+        assert.ok(email || idToken, "owner.email or owner.idToken is required");
+
+        if (consents) {
+            assertArray(consents, "consents");
+            for (const { consentRevisionId, action } of consents) {
+                assertString(consentRevisionId, "consentRevisionId");
+                assertNullOrString(action, "action");
+            }
+        }
+
+        return this._apiClient
+            .request(`/organizations`, {
+                method: "POST",
+                data: {
+                    organizationName,
+                    type: "private",
+                    subdomain,
+                    owner: {
+                        ...(email && { email }),
+                        ...(idToken && { idToken }),
+                        ...(consents && { consents }),
+                        displayName,
+                    },
+                },
+            })
+            .then(({ data }) => {
+                return extractString(data, "organizationId");
+            });
+    }
+
+    /**
+     * Retrieves the organization based on the subdomain.
+     */
+    getOrganizationBySubdomain(subdomain: string): Promise<Organization | null> {
+        assertString(subdomain, "subdomain");
+
+        return this._apiClient
+            .request(
+                `/organization-subdomains/${encodeURIComponent(
+                    subdomain
+                )}/?fields=permissions,account,onboardingSurvey`,
+                {
+                    method: "GET",
+                }
+            )
+
+            .then(({ data }) => {
+                return Organization.fromJson(data);
+            })
+            .catch((res) => {
+                if (res instanceof Response) {
+                    if (res.status === 404) {
+                        return null;
+                    }
+
+                    throw new Error(res.statusText);
+                }
+
+                throw res;
+            });
+    }
+
+    /**
+     * Retrieves the organization based on the organizationId.
+     *
+     * Note: This endpoint should only be used to retrieve an organization when the device is linked
+     * to a user in that organization. Use getOrganizationBySubdomain instead if you just want the information
+     * about an organization that is mapped to a given subdomain.
+     */
+    getOrganizationByOrganizationId(organizationId: string): Promise<Organization | null> {
+        assertString(organizationId, "organizationId");
+
+        return this._apiClient
+            .request(`/organizations/${encodeURIComponent(organizationId)}?fields=permissions,account`, {
+                method: "GET",
+            })
+            .then(({ data }) => {
+                return Organization.fromJson(data);
+            })
+            .catch((res) => {
+                if (res instanceof Response) {
+                    if (res.status === 404) {
+                        return null;
+                    }
+
+                    throw new Error(res.statusText);
+                }
+
+                throw res;
+            });
+    }
+
+    /**
+     * Retrieves the organizations that contain a user
+     * matching provided the email+code or phoneNumber+code
+     * combination.
+     */
+    getOrganizationsByContactPoint(
+        options:
+            | {
+                  email: string;
+                  code: string;
+              }
+            | {
+                  phoneNumber: string;
+                  code: string;
+              }
+    ): Promise<ReadonlyArray<Organization>> {
+        const { code } = options;
+        const email = "email" in options ? options.email : null;
+        const phoneNumber = "phoneNumber" in options ? options.phoneNumber : null;
+        assert.ok((email || phoneNumber) && !(email && phoneNumber), "either email or phoneNumber is required");
+        assertString(code, "code");
+
+        const contactPoint = email ? { type: "email", value: email } : { type: "phoneNumber", value: phoneNumber };
+        return this._apiClient
+            .request("/organization-queries", {
+                method: "POST",
+                data: {
+                    contactPoint,
+                    code,
+                },
+            })
+            .then(({ data }) => {
+                return extractArray(data, "organizations", (organization) => Organization.fromJson(organization));
+            });
+    }
+
+    /**
+     * Retrieves the organizations that contain a user
+     * matching provided the idToken
+     */
+    getOrganizationsByIdToken({ idToken }: { idToken: string }): Promise<ReadonlyArray<Organization>> {
+        assertString(idToken, "idToken");
+
+        return this._apiClient
+            .request("/organization-queries", {
+                method: "POST",
+                data: {
+                    idToken,
+                },
+            })
+            .then(({ data }) => {
+                return extractArray(data, "organizations", (organization) => {
+                    return Organization.fromJson({
+                        permissions: {},
+                        limits: {},
+                        ...assertRecord(organization, "organization"),
+                    });
+                });
+            });
+    }
+
+    /**
+     * Retrieves the organizations containing a user
+     * with either the email or phoneNumber matching the logged in user.
+     *
+     * This is useful for showing the possible organization that the current
+     * user could log in to.
+     */
+    getOrganizationsByLoggedInUser(): Promise<ReadonlyArray<Organization>> {
+        return this._apiClient
+            .request("/user/organizations", {
+                method: "GET",
+            })
+            .then(({ data }) => {
+                return extractArray(data, "organizations", (o) => {
+                    return Organization.fromJson({
+                        permissions: {},
+                        limits: {},
+                        ...assertRecord(o, "organization"),
+                    });
+                });
+            });
+    }
+
+    /**
+     * Checks if a subdomain is available and verifies its format.
+     */
+    getSubdomainAvailability(subdomain: string): Promise<{ status: string }> {
+        assertString(subdomain, "subdomain");
+
+        return this._apiClient
+            .request(`/organization-subdomains/${encodeURIComponent(subdomain)}/availability`, {
+                method: "GET",
+            })
+            .then(({ data }) => {
+                assertInstanceOf(data, Object, "data");
+
+                return {
+                    status: extractString(data, "status"),
+                };
+            });
+    }
+    /**
+     * Updates preferences of the organization.
+     */
+    updatePreferences({
+        organizationId,
+        preferences,
+    }: {
+        organizationId: string;
+        preferences: OrganizationPreferences;
+    }): Promise<undefined> {
+        assertTruthy(organizationId, "organizationId");
+        assertTruthy(preferences, "preferences");
+        return this._apiClient
+            .request(`/organizations/${encodeURIComponent(organizationId)}/preferences`, {
+                method: "PATCH",
+                data: preferences,
+            })
+            .then(() => undefined);
+    }
+    /**
+     * Delete organization
+     */
+    deleteOrganization({ organizationId }: { organizationId: string }): Promise<undefined> {
+        assertTruthy(organizationId, "organizationId");
+        return this._apiClient
+            .request(`/organizations/${encodeURIComponent(organizationId)}`, {
+                method: "DELETE",
+            })
+            .then(() => undefined);
+    }
+}

--- a/src/lib/api/organizationService/tests/index.spec.ts
+++ b/src/lib/api/organizationService/tests/index.spec.ts
@@ -1,0 +1,820 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import ApiClient from "../../ApiClient";
+import _omit from "lodash/omit";
+import OrganizationService from "../index";
+import Organization from "../../models/Organization";
+import Response from "../../Response";
+import { itShouldThrowIfInvalid, itShouldRejectIfApiClientRejects } from "../../test/helpers";
+import { ConsentGrantRequest } from "../../types";
+
+function createOrganizationResponseObjectFromId(organizationId: string) {
+    return {
+        organizationId,
+        organizationName: "orgName-" + organizationId,
+        subdomain: "subdomain-" + organizationId,
+        permissions: {},
+        limits: {},
+    };
+}
+
+function createOrganizationFromResponseObject(responseObject: Record<string, unknown>) {
+    return Organization.fromJson({
+        permissions: {},
+        limits: {},
+        ...responseObject,
+    });
+}
+
+describe("organizationService", () => {
+    let apiClient: sinon.SinonStubbedInstance<ApiClient>;
+    let organizationService: OrganizationService;
+    const organizationId = "1";
+    const organizationName = "some-name";
+    const subdomain = "someOrganization";
+    const verificationCode = "someVerificationCode";
+    const permissions = {
+        images: {
+            logoImageUrl: {
+                set: {
+                    isAllowed: true,
+                    isSupported: true,
+                },
+                reset: {
+                    isAllowed: true,
+                    isSupported: true,
+                },
+            },
+            roomBackgroundImageUrl: {
+                set: {
+                    isAllowed: true,
+                    isSupported: true,
+                },
+                reset: {
+                    isAllowed: true,
+                    isSupported: true,
+                },
+            },
+            roomKnockPageBackgroundImageUrl: {
+                set: {
+                    isAllowed: true,
+                    isSupported: true,
+                },
+                reset: {
+                    isAllowed: true,
+                    isSupported: true,
+                },
+            },
+        },
+        invitations: {
+            add: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            delete: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            list: {
+                isAllowed: true,
+                isSupported: true,
+            },
+        },
+        roles: {
+            set: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            remove: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            removeSelf: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            list: {
+                isAllowed: true,
+                isSupported: true,
+            },
+        },
+        users: {
+            signUpWithoutInvitation: {
+                isAllowed: true,
+                isSupported: true,
+            },
+        },
+        rooms: {
+            customize: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            customizeSelf: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            list: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            lock: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            unclaim: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            unclaimSelf: {
+                isAllowed: true,
+                isSupported: true,
+            },
+        },
+        subscriptions: {
+            add: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            list: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            payLatestInvoice: {
+                isAllowed: true,
+                isSupported: true,
+            },
+            updatePlan: {
+                isAllowed: true,
+                isSupported: true,
+            },
+        },
+        browserExtension: {
+            install: {
+                isAllowed: true,
+                isSupported: true,
+            },
+        },
+    };
+    const limits = {
+        maxNumberOfInvitationsAndUsers: null,
+        maxNumberOfClaimedRooms: null,
+        maxRoomLimitPerOrganization: null,
+    };
+
+    beforeEach(() => {
+        apiClient = sinon.createStubInstance(ApiClient);
+
+        organizationService = new OrganizationService({ apiClient });
+    });
+
+    describe("constructor", () => {
+        itShouldThrowIfInvalid(
+            "apiClient",
+            () =>
+                new OrganizationService({
+                    //@ts-expect-error
+                    apiClient: undefined,
+                })
+        );
+    });
+
+    describe("createOrganization", () => {
+        const consents: Array<ConsentGrantRequest> = [
+            {
+                consentRevisionId: "Test consentRevisionId",
+                action: "rejected",
+            },
+        ];
+        const emailOwner = {
+            email: "owner-email@example.com",
+            verificationCode,
+            displayName: "owner-displayName",
+            consents,
+        };
+        const idTokenOwner = {
+            idToken: "mockIdToken",
+            displayName: "owner-displayName",
+        };
+        const createOrganizationArgs = {
+            subdomain,
+            organizationName,
+        };
+        const createOrganizationWithEmailArgs = {
+            ...createOrganizationArgs,
+            owner: emailOwner,
+        };
+        const createOrganizationWithIdTokenArgs = {
+            ...createOrganizationArgs,
+            owner: idTokenOwner,
+        };
+
+        const createdOrganization = {
+            organizationId,
+            permissions: {},
+            limits: {},
+        };
+
+        describe("when missing arguments", () => {
+            itShouldThrowIfInvalid("subdomain", () => {
+                // @ts-expect-error
+                organizationService.createOrganization(_omit(createOrganizationWithEmailArgs, "subdomain"));
+            });
+
+            itShouldThrowIfInvalid("organizationName", () => {
+                // @ts-expect-error
+                organizationService.createOrganization(_omit(createOrganizationWithEmailArgs, "organizationName"));
+            });
+
+            itShouldThrowIfInvalid("owner.email or owner.idToken", () => {
+                organizationService.createOrganization({
+                    ...createOrganizationArgs,
+                    //@ts-expect-error
+                    owner: { displayName: idTokenOwner.displayName },
+                });
+            });
+
+            describe("owner.email", () => {
+                itShouldThrowIfInvalid("owner.verificationCode", () => {
+                    organizationService.createOrganization({
+                        ...createOrganizationWithEmailArgs,
+                        //@ts-expect-error
+                        owner: _omit(createOrganizationWithEmailArgs.owner, "verificationCode"),
+                    });
+                });
+            });
+
+            describe("owner.idToken", () => {
+                itShouldThrowIfInvalid("owner.idToken", () => {
+                    organizationService.createOrganization({
+                        ...createOrganizationWithIdTokenArgs,
+                        //@ts-expect-error
+                        owner: {
+                            ..._omit(createOrganizationWithIdTokenArgs.owner, "idToken"),
+                        },
+                    });
+                });
+            });
+
+            itShouldThrowIfInvalid("owner.displayName", () => {
+                organizationService.createOrganization({
+                    ...createOrganizationWithEmailArgs,
+                    //@ts-expect-error
+                    owner: _omit(createOrganizationWithEmailArgs.owner, "displayName"),
+                });
+            });
+
+            itShouldThrowIfInvalid("consents", () => {
+                organizationService.createOrganization({
+                    ...createOrganizationWithIdTokenArgs,
+                    owner: {
+                        ...createOrganizationWithIdTokenArgs.owner,
+                        //@ts-expect-error
+                        consents: "invalid",
+                    },
+                });
+            });
+        });
+
+        describe("when using email", () => {
+            it("should resolve with the organizationId of the created organization", async () => {
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            ...createdOrganization,
+                            ...createOrganizationWithEmailArgs,
+                        },
+                    })
+                );
+
+                const result = await organizationService.createOrganization(createOrganizationWithEmailArgs);
+
+                expect(result).to.eql(createdOrganization.organizationId);
+            });
+
+            it("should correctly format the API request", () => {
+                const expectedUrl = `/organizations`;
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            ...createdOrganization,
+                            ...createOrganizationWithEmailArgs,
+                        },
+                    })
+                );
+
+                const promise = organizationService.createOrganization(createOrganizationWithEmailArgs);
+
+                return promise.then(() => {
+                    expect(apiClient.request).to.have.been.calledWithExactly(expectedUrl, {
+                        method: "POST",
+                        data: {
+                            owner: {
+                                displayName: createOrganizationWithEmailArgs.owner.displayName,
+                                email: {
+                                    value: createOrganizationWithEmailArgs.owner.email,
+                                    verificationCode: createOrganizationWithEmailArgs.owner.verificationCode,
+                                },
+                                consents: createOrganizationWithEmailArgs.owner.consents,
+                            },
+                            organizationName: createOrganizationWithEmailArgs.organizationName,
+                            subdomain: createOrganizationWithEmailArgs.subdomain,
+                            type: "private",
+                        },
+                    });
+                });
+            });
+        });
+
+        describe("when using idToken", () => {
+            it("should resolve with the organizationId of the created organization", async () => {
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            ...createdOrganization,
+                            ...createOrganizationWithIdTokenArgs,
+                        },
+                    })
+                );
+
+                const result = await organizationService.createOrganization(createOrganizationWithIdTokenArgs);
+
+                expect(result).to.eql(createdOrganization.organizationId);
+            });
+
+            it("should correctly format the API request", () => {
+                const expectedUrl = `/organizations`;
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            ...createdOrganization,
+                            ...createOrganizationWithIdTokenArgs,
+                        },
+                    })
+                );
+
+                const promise = organizationService.createOrganization(createOrganizationWithIdTokenArgs);
+
+                return promise.then(() => {
+                    expect(apiClient.request).to.have.been.calledWithExactly(expectedUrl, {
+                        method: "POST",
+                        data: {
+                            owner: {
+                                displayName: createOrganizationWithIdTokenArgs.owner.displayName,
+                                idToken: createOrganizationWithIdTokenArgs.owner.idToken,
+                            },
+                            organizationName: createOrganizationWithIdTokenArgs.organizationName,
+                            subdomain: createOrganizationWithIdTokenArgs.subdomain,
+                            type: "private",
+                        },
+                    });
+                });
+            });
+        });
+    });
+
+    describe("getOrganizationBySubdomain", () => {
+        beforeEach(() => {
+            apiClient.request.rejects(new Error("Called request method with unexpected parameters"));
+        });
+
+        itShouldThrowIfInvalid("subdomain", () => {
+            //@ts-expect-error
+            organizationService.getOrganizationBySubdomain(null);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.getOrganizationBySubdomain(subdomain)
+        );
+
+        it("should return null if no matching organization was found", async () => {
+            apiClient.request.rejects(
+                new Response({
+                    status: 404,
+                })
+            );
+
+            const result = await organizationService.getOrganizationBySubdomain(subdomain);
+
+            expect(result).to.eql(null);
+        });
+
+        it("should return the matching organization", async () => {
+            const data = {
+                organizationId,
+                organizationName,
+                subdomain,
+                permissions,
+                limits,
+            };
+            apiClient.request
+                .withArgs(
+                    `/organization-subdomains/${encodeURIComponent(
+                        subdomain
+                    )}/?fields=permissions,account,onboardingSurvey`,
+                    {
+                        method: "GET",
+                    }
+                )
+                .resolves(
+                    new Response({
+                        status: 200,
+                        data,
+                    })
+                );
+
+            const result = await organizationService.getOrganizationBySubdomain(subdomain);
+
+            expect(result).to.eql(Organization.fromJson(data));
+        });
+
+        it("should support retrieving organization with empty subdomain", async () => {
+            apiClient.request
+                .withArgs(`/organization-subdomains//?fields=permissions,account,onboardingSurvey`, {
+                    method: "GET",
+                })
+                .resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            organizationId,
+                            organizationName,
+                            subdomain,
+                            permissions,
+                            limits,
+                        },
+                    })
+                );
+
+            const result = await organizationService.getOrganizationBySubdomain("");
+
+            expect(result).to.eql(
+                Organization.fromJson({
+                    organizationId,
+                    organizationName,
+                    subdomain,
+                    permissions,
+                    limits,
+                })
+            );
+        });
+    });
+
+    describe("getOrganizationByOrganizationId", () => {
+        beforeEach(() => {
+            const response = new Response({ status: 200, data: {} });
+            apiClient.request.resolves(response);
+        });
+
+        itShouldThrowIfInvalid("organizationId", () => {
+            //@ts-expect-error
+            organizationService.getOrganizationByOrganizationId(null);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.getOrganizationByOrganizationId(organizationId)
+        );
+
+        it("should return null if no matching organization was found", async () => {
+            apiClient.request.rejects(
+                new Response({
+                    status: 404,
+                })
+            );
+
+            const result = await organizationService.getOrganizationByOrganizationId(organizationId);
+
+            expect(result).to.eql(null);
+        });
+
+        it("should return the matching organization", async () => {
+            apiClient.request
+                .withArgs(`/organizations/${encodeURIComponent(organizationId)}?fields=permissions,account`, {
+                    method: "GET",
+                })
+                .resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            organizationId,
+                            organizationName,
+                            subdomain,
+                            permissions,
+                            limits,
+                        },
+                    })
+                );
+
+            const result = await organizationService.getOrganizationByOrganizationId(organizationId);
+
+            expect(result).to.eql(
+                Organization.fromJson({
+                    organizationId,
+                    organizationName,
+                    subdomain,
+                    permissions,
+                    limits,
+                })
+            );
+        });
+    });
+
+    describe("getOrganizationsByContactPoint", () => {
+        let email: string;
+        let phoneNumber: string;
+        let code: string;
+
+        beforeEach(() => {
+            email = "some-email@example.com";
+            phoneNumber = "+111";
+            code = "some code";
+
+            const response = new Response({
+                status: 200,
+                data: {
+                    organizations: [],
+                },
+            });
+            apiClient.request.resolves(response);
+        });
+
+        itShouldThrowIfInvalid("code", () => {
+            // @ts-expect-error
+            organizationService.getOrganizationsByContactPoint({ email });
+        });
+
+        it("should throw if both email and phoneNumber are missing", () => {
+            expect(() => {
+                // @ts-expect-error
+                organizationService.getOrganizationsByContactPoint({ code });
+            }).to.throw("email or phoneNumber is required");
+        });
+
+        it("should throw if both email and phoneNumber are provided", () => {
+            expect(() => {
+                organizationService.getOrganizationsByContactPoint({ email, phoneNumber, code });
+            }).to.throw("email or phoneNumber is required");
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.getOrganizationsByContactPoint({ email, code })
+        );
+
+        describe("when phoneNumber is provided", () => {
+            it("should return empty array if no matching organizations were found", async () => {
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: { organizations: [] },
+                    })
+                );
+
+                const result = await organizationService.getOrganizationsByContactPoint({ phoneNumber, code });
+
+                expect(result).to.eql([]);
+            });
+
+            it("should return the matching organizations", async () => {
+                const organizationsPayload = ["1", "2", "3"].map(createOrganizationResponseObjectFromId);
+                const expectedOrganizations = organizationsPayload.map(createOrganizationFromResponseObject);
+                apiClient.request
+                    .withArgs("/organization-queries", {
+                        method: "POST",
+                        data: {
+                            contactPoint: { type: "phoneNumber", value: phoneNumber },
+                            code,
+                        },
+                    })
+                    .resolves(
+                        new Response({
+                            status: 200,
+                            data: { organizations: organizationsPayload },
+                        })
+                    );
+
+                const result = await organizationService.getOrganizationsByContactPoint({ phoneNumber, code });
+
+                expect(result).to.eql(expectedOrganizations);
+            });
+        });
+
+        describe("when email is provided", () => {
+            it("should return empty array if no matching organizations were found", async () => {
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {
+                            organizations: [],
+                        },
+                    })
+                );
+
+                const result = await organizationService.getOrganizationsByContactPoint({ email, code });
+
+                expect(result).to.eql([]);
+            });
+
+            it("should return the matching organizations", async () => {
+                const organizationsPayload = ["1", "2", "3"].map(createOrganizationResponseObjectFromId);
+                const expectedOrganizations = organizationsPayload.map(createOrganizationFromResponseObject);
+                apiClient.request
+                    .withArgs("/organization-queries", {
+                        method: "POST",
+                        data: {
+                            contactPoint: { type: "email", value: email },
+                            code,
+                        },
+                    })
+                    .resolves(
+                        new Response({
+                            status: 200,
+                            data: { organizations: organizationsPayload },
+                        })
+                    );
+
+                const result = await organizationService.getOrganizationsByContactPoint({ email, code });
+
+                expect(result).to.eql(expectedOrganizations);
+            });
+        });
+    });
+
+    describe("getOrganizationsByIdToken", () => {
+        let idToken: string;
+
+        beforeEach(() => {
+            idToken = "some-id-token";
+
+            const response = new Response({
+                status: 200,
+                data: {
+                    organizations: [],
+                },
+            });
+            apiClient.request.resolves(response);
+        });
+
+        itShouldThrowIfInvalid("idToken", () => {
+            // @ts-expect-error
+            organizationService.getOrganizationsByIdToken({});
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.getOrganizationsByIdToken({ idToken })
+        );
+
+        describe("when idToken is provided", () => {
+            it("should return empty array if no matching organizations were found", async () => {
+                apiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: { organizations: [] },
+                    })
+                );
+
+                const result = await organizationService.getOrganizationsByIdToken({ idToken });
+
+                expect(result).to.eql([]);
+            });
+
+            it("should return the matching organizations", async () => {
+                const organizationsPayload = ["1", "2", "3"].map(createOrganizationResponseObjectFromId);
+                const expectedOrganizations = organizationsPayload.map(createOrganizationFromResponseObject);
+                apiClient.request.withArgs("/organization-queries", { method: "POST", data: { idToken } }).resolves(
+                    new Response({
+                        status: 200,
+                        data: { organizations: organizationsPayload },
+                    })
+                );
+
+                const result = await organizationService.getOrganizationsByIdToken({ idToken });
+
+                expect(result).to.eql(expectedOrganizations);
+            });
+        });
+    });
+
+    describe("getOrganizationsByLoggedInUser", () => {
+        beforeEach(() => {
+            const response = new Response({
+                status: 200,
+                data: {
+                    organizations: [],
+                },
+            });
+            apiClient.request.resolves(response);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.getOrganizationsByLoggedInUser()
+        );
+
+        it("should return empty array if no matching organizations were found", async () => {
+            apiClient.request.resolves(
+                new Response({
+                    status: 200,
+                    data: { organizations: [] },
+                })
+            );
+
+            const result = await organizationService.getOrganizationsByLoggedInUser();
+
+            return expect(result).to.eql([]);
+        });
+
+        it("should return the matching organizations", async () => {
+            const organizationsPayload = ["1", "2", "3"].map(createOrganizationResponseObjectFromId);
+            const expectedOrganizations = organizationsPayload.map(createOrganizationFromResponseObject);
+            apiClient.request
+                .withArgs("/user/organizations", {
+                    method: "GET",
+                })
+                .resolves(
+                    new Response({
+                        status: 200,
+                        data: { organizations: organizationsPayload },
+                    })
+                );
+
+            const result = await organizationService.getOrganizationsByLoggedInUser();
+
+            expect(result).to.eql(expectedOrganizations);
+        });
+    });
+
+    describe("getSubdomainAvailability", () => {
+        itShouldThrowIfInvalid("subdomain", () => {
+            //@ts-expect-error
+            organizationService.getSubdomainAvailability(null);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.getSubdomainAvailability(subdomain)
+        );
+
+        it("should return the data provided by the server", async () => {
+            const data = {
+                status: "available",
+            };
+            apiClient.request
+                .withArgs(`/organization-subdomains/${encodeURIComponent(subdomain)}/availability`, { method: "GET" })
+                .resolves(
+                    new Response({
+                        status: 200,
+                        data,
+                    })
+                );
+
+            const result = await organizationService.getSubdomainAvailability(subdomain);
+
+            expect(result).to.eql(data);
+        });
+    });
+
+    describe("updatePreferences", () => {
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.updatePreferences({ organizationId: "2", preferences: {} })
+        );
+
+        it("should update preferences", async () => {
+            const expectedUrl = `/organizations/${organizationId}/preferences`;
+            const preferences = { someKey: "some value" };
+            apiClient.request.resolves(new Response({ status: 204, data: null }));
+
+            await organizationService.updatePreferences({ organizationId, preferences });
+
+            expect(apiClient.request).to.have.been.calledWithExactly(expectedUrl, {
+                method: "PATCH",
+                data: preferences,
+            });
+        });
+    });
+
+    describe("deleteOrganization", () => {
+        itShouldRejectIfApiClientRejects(
+            () => apiClient,
+            () => organizationService.deleteOrganization({ organizationId: "2" })
+        );
+
+        it("should delete organization", async () => {
+            const expectedUrl = `/organizations/${organizationId}`;
+            apiClient.request.resolves(new Response({ status: 204, data: null }));
+
+            await organizationService.deleteOrganization({ organizationId });
+
+            expect(apiClient.request).to.have.been.calledWithExactly(expectedUrl, {
+                method: "DELETE",
+            });
+        });
+    });
+});

--- a/src/lib/api/organizationServiceCache/index.ts
+++ b/src/lib/api/organizationServiceCache/index.ts
@@ -1,0 +1,28 @@
+import { assertInstanceOf, assertString } from "../parameterAssertUtils";
+import OrganizationService from "../organizationService/index";
+import Organization from "../models/Organization";
+
+export default class OrganizationServiceCache {
+    private _organizationService: OrganizationService;
+    private _subdomain: string;
+    private _organizationPromise: Promise<Organization | null> | null;
+
+    constructor({ organizationService, subdomain }: { organizationService: OrganizationService; subdomain: string }) {
+        assertInstanceOf(organizationService, OrganizationService);
+        assertString(subdomain, "subdomain");
+        this._organizationService = organizationService;
+        this._subdomain = subdomain;
+        this._organizationPromise = null;
+    }
+
+    initOrganization(): Promise<void> {
+        return this.fetchOrganization().then(() => undefined);
+    }
+
+    fetchOrganization(): Promise<Organization | null> {
+        if (!this._organizationPromise) {
+            this._organizationPromise = this._organizationService.getOrganizationBySubdomain(this._subdomain);
+        }
+        return this._organizationPromise;
+    }
+}

--- a/src/lib/api/organizationServiceCache/tests/index.spec.ts
+++ b/src/lib/api/organizationServiceCache/tests/index.spec.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+import sinon from "sinon";
+import OrganizationServiceCache from "../index";
+import OrganizationService from "../../organizationService";
+import Organization from "../../models/Organization";
+import { itShouldThrowIfInvalid } from "../../test/helpers";
+
+describe("OrganizationServiceCache", () => {
+    let organizationService;
+    let organizationServiceCache;
+    let subdomain;
+    let organization;
+
+    beforeEach(() => {
+        subdomain = "someOrganization";
+        const permissions = {};
+        const limits = {
+            maxNumberOfClaimedRooms: null,
+        };
+
+        organization = new Organization({
+            organizationId: "1",
+            organizationName: "some-name",
+            subdomain: "someOrganization",
+            permissions,
+            limits,
+        });
+        organizationService = sinon.createStubInstance(OrganizationService);
+        organizationService.getOrganizationBySubdomain.resolves(organization);
+        organizationServiceCache = new OrganizationServiceCache({
+            subdomain,
+            organizationService,
+        });
+    });
+
+    describe("constructor", () => {
+        itShouldThrowIfInvalid(
+            "subdomain",
+            () =>
+                new OrganizationServiceCache({
+                    subdomain: undefined,
+                    organizationService,
+                })
+        );
+
+        itShouldThrowIfInvalid(
+            "organizationService",
+            () =>
+                new OrganizationServiceCache({
+                    subdomain,
+                    organizationService: undefined,
+                })
+        );
+    });
+
+    describe("initOrganization", () => {
+        describe("when cache is uninitialized", () => {
+            it("should fetch the organization", () => {
+                const promise = organizationServiceCache.initOrganization();
+
+                return promise.then(() => {
+                    expect(
+                        organizationService.getOrganizationBySubdomain.withArgs(subdomain)
+                    ).to.have.been.calledOnce();
+                });
+            });
+        });
+
+        describe("when cache is initialized", () => {
+            beforeEach(() => {
+                return organizationServiceCache.initOrganization();
+            });
+
+            it("should do nothing", () => {
+                const promise = organizationServiceCache.initOrganization();
+
+                return promise.then(() => {
+                    expect(
+                        organizationService.getOrganizationBySubdomain.withArgs(subdomain)
+                    ).to.have.been.calledOnce();
+                });
+            });
+        });
+
+        it("should resolve with undefined", async () => {
+            const result = await organizationServiceCache.initOrganization();
+
+            expect(result).to.eql(undefined);
+        });
+    });
+
+    describe("fetchOrganization", () => {
+        describe("when cache is uninitialized", () => {
+            it("should fetch the organization state", () => {
+                const promise = organizationServiceCache.fetchOrganization();
+
+                return promise.then(() => {
+                    expect(
+                        organizationService.getOrganizationBySubdomain.withArgs(subdomain)
+                    ).to.have.been.calledOnce();
+                });
+            });
+        });
+
+        describe("when organization has been fetched once", () => {
+            beforeEach(() => {
+                return organizationServiceCache.fetchOrganization();
+            });
+
+            it("should do nothing", () => {
+                const promise = organizationServiceCache.fetchOrganization();
+
+                return promise.then(() => {
+                    expect(
+                        organizationService.getOrganizationBySubdomain.withArgs(subdomain)
+                    ).to.have.been.calledOnce();
+                });
+            });
+        });
+
+        it("should return the organization returned from the organizationService", async () => {
+            const result = await organizationServiceCache.fetchOrganization();
+
+            expect(result).to.eql(organization);
+        });
+    });
+});

--- a/src/lib/api/parameterAssertUtils.ts
+++ b/src/lib/api/parameterAssertUtils.ts
@@ -1,0 +1,166 @@
+import assert from "assert";
+
+/**
+ * Asserts that value is truthy.
+ *
+ * @param value - The value to check.
+ * @param {string} parameterName - The name of the parameter.
+ */
+export function assertTruthy(value: unknown, parameterName: string): unknown {
+    assert.ok(value, `${parameterName} is required`);
+    return value;
+}
+
+/**
+ * Asserts that value is a number.
+ *
+ * @param value - The value to check.
+ * @param {string} parameterName - The name of the parameter.
+ */
+export function assertBoolean(value: unknown, parameterName: string): boolean {
+    assert.ok(typeof value === "boolean", `${parameterName}<boolean> is required`);
+    return value;
+}
+
+/**
+ * Asserts that value is a number.
+ *
+ * @param value - The value to check.
+ * @param {string} parameterName - The name of the parameter.
+ */
+export function assertNumber(value: unknown, parameterName: string): number {
+    assert.ok(typeof value === "number", `${parameterName}<number> is required`);
+    return value;
+}
+
+/**
+ * Asserts that value is a string.
+ *
+ * @param value - The value to check.
+ * @param {string} parameterName - The name of the parameter.
+ */
+export function assertString(value: unknown, parameterName: string): string {
+    assert.ok(typeof value === "string", `${parameterName}<string> is required`);
+    return value;
+}
+
+/**
+ * Asserts that value is of the provided type.
+ *
+ * @param value - The value to check.
+ * @param type - The type that value should be.
+ * @param {string} [parameterName] - The name of the parameter.
+ */
+export function assertInstanceOf<T>(value: unknown, type: new (any: any) => T, parameterName?: string): T {
+    const resolvedParameterName = parameterName || type.name[0].toLowerCase() + type.name.substring(1);
+    assert.ok(value instanceof type, `${resolvedParameterName}<${type.name}> is required`);
+    return value;
+}
+
+/**
+ * Asserts that the provided room name is a valid roomName.
+ *
+ * @param roomName - The roomName to check.
+ * @param {string} [parameterName="roomName"] - The name of the parameter.
+ */
+export function assertRoomName(roomName: unknown, parameterName = "roomName"): string {
+    assertString(roomName, parameterName);
+    assert.equal(typeof roomName === "string" && roomName[0], "/", `${parameterName} must begin with a '/'`);
+    return roomName as string;
+}
+
+/**
+ * Asserts that the provided array is a valid array.
+ *
+ * @param array - The array to check.
+ * @param {string} [parameterName] - The name of the parameter.
+ */
+export function assertArray(array: unknown, parameterName: string): Array<unknown> {
+    assert.ok(Array.isArray(array), `${parameterName}<array> is required`);
+    return array as Array<unknown>;
+}
+
+/**
+ * Asserts that value is one of the values provided in an array
+ *
+ * @param value - The value to check.
+ * @param allowedValues - An array of allowed values
+ * @param {string} parameterName - The name of the parameter.
+ */
+export function assertOneOf<T>(value: T, allowedValues: Array<unknown>, parameterName: string): T {
+    assertTruthy(value, "value");
+    assertArray(allowedValues, "allowedValues");
+
+    const isAllowed = allowedValues.includes(value);
+    if (!isAllowed) {
+        throw new Error(`${parameterName}<string> must be one of the following: ${allowedValues.join(", ")}`);
+    }
+
+    return value;
+}
+
+/**
+ * Asserts that the provided reference is of the provided primitive type.
+ *
+ * @param {*} ref - The reference (variable or constant) to test.
+ * @param {string} type - The expected primitive type.
+ * @param {string} name - The name of the reference, will be used in the error message.
+ * @param {string} [message] - A custom message to use when the assertion fails.
+ */
+export function assertType(ref: unknown, type: string, name: string, message?: string): void {
+    assert.ok(typeof name === "string", "name must be of type string");
+    const errorMessage = message || `${name} must be of type ${type}`;
+    assert.ok(ref !== null && typeof ref === type, errorMessage);
+}
+
+/**
+ * Asserts that the provided reference is a record.
+ *
+ * @param {*} ref - The reference (variable or constant) to test.
+ * @param {string} name - The name of the reference, will be used in the error message.
+ */
+export function assertRecord(ref: unknown, name: string): Record<string, unknown> {
+    if (ref === null || ref === undefined || typeof ref !== "object" || Array.isArray(ref)) {
+        throw new Error(`${name} must be a record. ${JSON.stringify(ref)}`);
+    }
+
+    return ref as Record<string, unknown>;
+}
+
+/**
+ * Asserts that the provided reference is either null or of the provided primitive type.
+ *
+ * @param {*} ref - The reference (variable or constant) to test.
+ * @param {string} type - The expected primitive type.
+ * @param {string} name - The name of the reference, will be used in the error message.
+ * @param {string} [message] - A custom message to use when the assertion fails.
+ */
+export function assertNullOrType(ref: unknown, type: string, name: string, message?: string): void {
+    assertString(name, "name");
+    const errorMessage = message || `${name} must be null or of type ${type}`;
+    assert.ok(ref === null || typeof ref === type, errorMessage);
+}
+
+/**
+ * Asserts that the provided reference is either null or a boolean.
+ *
+ * @param {*} ref - The reference (variable or constant) to test.
+ * @param {string} name - The name of the reference, will be used in the error message.
+ * @param {string} [message] - A custom message to use when the assertion fails.
+ */
+export function assertNullOrBoolean(ref: unknown, name: string, message?: string): void {
+    assertString(name, "name");
+    assertNullOrType(ref, "boolean", name, message);
+}
+
+/**
+ * Asserts that the provided reference is either null or a string.
+ *
+ * @param {*} ref - The reference (variable or constant) to test.
+ * @param {string} name - The name of the reference, will be used in the error message.
+ * @param {string} [message] - A custom message to use when the assertion fails.
+ */
+export function assertNullOrString(ref: unknown, name: string, message?: string): void {
+    assertString(name, "name");
+    assertNullOrType(ref, "string", name, message);
+}

--- a/src/lib/api/roomService/index.ts
+++ b/src/lib/api/roomService/index.ts
@@ -1,0 +1,310 @@
+// @ts-nocheck
+import Room from "../models/Room";
+import {
+    assertInstanceOf,
+    assertRoomName,
+    assertString,
+    assertArray,
+    assertOneOf,
+    assertNumber,
+} from "../parameterAssertUtils";
+import OrganizationApiClient from "../OrganizationApiClient";
+import Meeting from "../models/Meeting";
+
+function createRoomUrl(roomName, path = "") {
+    const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+    return `/room/${encodedDisplayName}${path}`;
+}
+
+/**
+ * Service for talking to the Room related APIs
+ */
+export default class RoomService {
+    /**
+     * @param {object} organizationApiClient (required)
+     */
+    constructor({ organizationApiClient }) {
+        this._organizationApiClient = assertInstanceOf(organizationApiClient, OrganizationApiClient);
+    }
+
+    /**
+     * Gets the list of visited rooms
+     *
+     * @param {Object} args
+     * @param {Array<string>} [types=["team"]] - The type of rooms that should be fetched.
+     * @param {Array<string>} [fields=["meeting"]] - The fields of room that should be fetched.
+     * @returns {Promise<array>} - It will resolve with an array.
+     */
+    getRooms({ types, fields = [] } = {}) {
+        assertArray(types, "types");
+        assertArray(fields, "fields");
+        return this._organizationApiClient
+            .request("/room", {
+                method: "GET",
+                params: { types: types.join(","), fields: fields.join(","), includeOnlyLegacyRoomType: "false" },
+            })
+            .then(({ data }) => data.rooms.map((room) => new Room(room)));
+    }
+
+    /**
+     * Gets the specified room.
+     *
+     * Currently information is implicitly alluded to via the servers
+     * `/room/roomName` response. This method patches the data
+     * tempoarily, until the day it comes back from the server.
+     *
+     * @returns {Promise<Room>} - It will resolve with the Room.
+     */
+    getRoom({ roomName, fields }: { roomName: string; fields?: Array<string> }): Promise<Room> {
+        assertRoomName(roomName);
+
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+
+        return this._organizationApiClient
+            .request(`/rooms/${encodedDisplayName}`, {
+                method: "GET",
+                params: { includeOnlyLegacyRoomType: "false", ...(fields && { fields: fields.join(",") }) },
+            })
+            .then(
+                ({ data }) =>
+                    new Room(
+                        Object.assign({}, data, {
+                            roomName,
+                            ...(data.meeting && { meeting: Meeting.fromJson(data.meeting) }),
+                        })
+                    )
+            )
+            .catch((response) => {
+                if (response.status === 404) {
+                    return new Room({
+                        roomName,
+                        isClaimed: false,
+                        mode: "normal",
+                        product: {
+                            categoryName: "personal_free",
+                        },
+                        type: "personal",
+                        legacyRoomType: "free",
+                    });
+                }
+
+                if (response.status === 400 && response.data.error === "Banned room") {
+                    return new Room({ roomName, isBanned: true });
+                }
+
+                // Either server error or something else.
+                throw new Error(response.data ? response.data.error : "Could not fetch room information");
+            });
+    }
+
+    /**
+     * Claims the specified room.
+     *
+     * @param {Object} args
+     * @param {String} args.roomName - The roomName to claim
+     * @param {String} args.type - The type of room to claim
+     * @param {String} args.mode - The optional mode of room to claim
+     * @param {[Boolean]} args.isLocked - The optional lock status of room to claim
+     * @returns {Promise} - It will resolve with undefined.
+     */
+    claimRoom({ roomName, type, mode, isLocked }) {
+        assertRoomName(roomName);
+        assertString(type, "type");
+
+        return this._organizationApiClient
+            .request("/room/claim", {
+                method: "POST",
+                data: {
+                    roomName,
+                    type,
+                    ...(typeof mode === "string" && { mode }),
+                    ...(typeof isLocked === "boolean" && { isLocked }),
+                },
+            })
+            .then(() => undefined)
+            .catch((response) => {
+                throw new Error(response.data.error || "Failed to claim room");
+            });
+    }
+
+    /**
+     * Unclaims the specified room.
+     *
+     * @param {string} roomName - the room name to unclaim.
+     * @returns {Promise.<undefined>} - It will resolve with undefined.
+     */
+    unclaimRoom(roomName) {
+        assertRoomName(roomName);
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+
+        return this._organizationApiClient
+            .request(`/room/${encodedDisplayName}`, {
+                method: "DELETE",
+            })
+            .then(() => undefined);
+    }
+
+    /**
+     * Changes the name of the room
+     *
+     * @param {Object} args
+     * @param {string} args.roomName - The name of the room to rename
+     * @param {string} args.newRoomName - The new name
+     * @returns {Promise<undefined>} - It will resolve if the room was renamed, reject for all other cases
+     */
+    renameRoom({ roomName, newRoomName }) {
+        assertRoomName(roomName);
+        assertString(newRoomName, "newRoomName");
+
+        const encodedRoomName = encodeURIComponent(roomName.substring(1));
+        return this._organizationApiClient
+
+            .request(`/room/${encodedRoomName}/roomName`, {
+                method: "PUT",
+                data: { newRoomName },
+            })
+            .then(() => undefined);
+    }
+
+    /**
+     * Changes the room mode (experimental)
+     *
+     * @param {string} roomName - The name of the room to change mode of
+     * @param {string} mode - The name of mode to set, currently only "group" is supported
+     * @returns {Promise<undefined>} - It will resolve if mode was changed, rejects for all other cases
+     */
+    changeMode({ roomName, mode }) {
+        assertRoomName(roomName);
+        assertString(mode, "mode");
+
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+        return this._organizationApiClient
+
+            .request(`/room/${encodedDisplayName}/mode`, {
+                method: "PUT",
+                data: { mode },
+            })
+            .then(() => undefined);
+    }
+
+    /**
+     * Updates the room prefs
+     *
+     * @param {string} roomName - The name of the room to change mode of
+     * @param {object} preferences - The prefs you want to update and their values
+     * @returns {Promise<undefined>} - It will resolve if updated, rejects for all other cases
+     */
+    updatePreferences({ roomName, preferences }) {
+        assertRoomName(roomName);
+        assertInstanceOf(preferences, Object, "preferences");
+
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+        return this._organizationApiClient
+            .request(`/room/${encodedDisplayName}/preferences`, {
+                method: "PATCH",
+                data: preferences,
+            })
+            .then(() => undefined);
+    }
+
+    /**
+     * Updates the protected room prefs
+     *
+     * @param {string} roomName - The name of the room to change mode of
+     * @param {object} preferences - The protected prefs you want to update and their values
+     * @returns {Promise<undefined>} - It will resolve if updated, rejects for all other cases
+     */
+    updateProtectedPreferences({ roomName, preferences }) {
+        assertRoomName(roomName);
+        assertInstanceOf(preferences, Object, "preferences");
+
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+        return this._organizationApiClient
+            .request(`/room/${encodedDisplayName}/protected-preferences`, {
+                method: "PATCH",
+                data: preferences,
+            })
+            .then(() => undefined);
+    }
+
+    getRoomPermissions(roomName, { roomKey } = {}) {
+        assertRoomName(roomName);
+
+        return this._organizationApiClient
+            .request(createRoomUrl(roomName, "/permissions"), {
+                method: "GET",
+                ...(roomKey && { headers: { "X-Whereby-Room-Key": roomKey } }),
+            })
+            .then((response) => {
+                const { permissions, limits } = response.data;
+                return {
+                    permissions,
+                    limits,
+                };
+            });
+    }
+
+    /**
+     * Gets the specified room metrics
+     *
+     * @param {Object} args
+     * @param {string} args.roomName - The name of the room to get metrics from.
+     * @param {string} args.metrics - Comma-separated list of metrics to include.
+     * @param {string} args.from (optional) - Start time (inclusive) to count from in
+     * ISO format. Defaults to counting from the start of time.
+     * @param {string} args.to (optional) - End time (exclusive) to count up to in
+     * ISO format. Defaults to counting up to the current time.
+     * @returns {Promise<Object>} - It will resolve with the requested metrics.
+     */
+    getRoomMetrics({ roomName, metrics, from, to }) {
+        assertRoomName(roomName);
+        assertString(metrics, "metrics");
+
+        return this._organizationApiClient
+            .request(createRoomUrl(roomName, "/metrics"), {
+                method: "GET",
+                params: { metrics, from, to },
+            })
+            .then((response) => response.data);
+    }
+
+    /**
+     * Changes the room type
+     *
+     * @param {Object} args
+     * @param {string} args.roomName - The name of the room to change mode of
+     * @param {"personal" | "personal_xl"} args.type - Room type that should be set
+     * @returns {Promise<undefined>} - It will resolve if type was changed, rejects for all other cases
+     */
+    changeType({ roomName, type }) {
+        assertRoomName(roomName);
+        assertOneOf(type, ["personal", "personal_xl"], "type");
+
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+        return this._organizationApiClient
+
+            .request(`/room/${encodedDisplayName}/type`, {
+                method: "PUT",
+                data: { type },
+            })
+            .then(() => undefined);
+    }
+
+    /** Gets a Forest campaign social image
+     *
+     * @param {Object} args
+     * @param {string} args.roomName - The name of the room to get metrics from.
+     * @param {number} args.count - Number to be displayed in the image as tree count.
+     * @returns {Promise<string>} - It will resolve with the image url.
+     */
+    getForestSocialImage({ roomName, count }) {
+        assertRoomName(roomName);
+        assertNumber(count, "count");
+
+        return this._organizationApiClient
+            .request(createRoomUrl(roomName, `/forest-social-image/${count}`), {
+                method: "GET",
+            })
+            .then((response) => response.data.imageUrl);
+    }
+}

--- a/src/lib/api/roomService/tests/index.spec.ts
+++ b/src/lib/api/roomService/tests/index.spec.ts
@@ -1,0 +1,691 @@
+// @ts-nocheck
+import sinon from "sinon";
+import OrganizationApiClient from "../../OrganizationApiClient";
+import Response from "../../Response";
+import RoomService from "../index";
+import Room from "../../models/Room";
+import Meeting from "../../models/Meeting";
+import { itShouldThrowIfInvalid, itShouldRejectIfApiClientRejects, toJson } from "../../test/helpers";
+
+describe("RoomService", () => {
+    let organizationApiClient;
+    let roomService;
+    const defaultParams = { includeOnlyLegacyRoomType: "false" };
+
+    beforeEach(() => {
+        organizationApiClient = sinon.createStubInstance(OrganizationApiClient);
+        roomService = new RoomService({
+            organizationApiClient,
+        });
+    });
+
+    describe("constructor", () => {
+        itShouldThrowIfInvalid(
+            "organizationApiClient",
+            () =>
+                new RoomService({
+                    organizationApiClient: undefined,
+                })
+        );
+    });
+
+    describe("getRooms", () => {
+        const url = "/room";
+        const method = "GET";
+
+        beforeEach(() => {
+            organizationApiClient.request.resolves();
+        });
+
+        itShouldThrowIfInvalid("types", () => roomService.getRooms());
+
+        function testGetRooms({ args, expectedTypes }) {
+            it(`should call request with types = [${expectedTypes}]`, () => {
+                roomService.getRooms(args);
+
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, {
+                    method,
+                    params: { types: expectedTypes, fields: "", ...defaultParams },
+                });
+            });
+
+            it("should transform data correctly", async () => {
+                const data = {
+                    rooms: [{ roomName: "/first-room" }, { roomName: "/second-room" }],
+                };
+                const expectedResult = [new Room({ roomName: "/first-room" }), new Room({ roomName: "/second-room" })];
+                organizationApiClient.request.resolves(new Response({ data }));
+
+                const result = await roomService.getRooms(args);
+
+                expect(result).to.eql(expectedResult);
+            });
+        }
+
+        describe("when types are provided", () => {
+            testGetRooms({ args: { types: ["team", "personal"], fields: [] }, expectedTypes: "team,personal" });
+        });
+    });
+
+    describe("getRoom", () => {
+        const roomName = "/some-random-name";
+        const uri = `/rooms${roomName}`;
+        const method = "GET";
+
+        itShouldThrowIfInvalid("roomName", () => roomService.getRoom({}));
+        // roomName must be a string
+        itShouldThrowIfInvalid("roomName", () => roomService.getRoom({ roomName: 23 }));
+
+        // roomName must begin with slash
+        it("should throw if `roomName` doesn't begin with a forward slash", () => {
+            const expectedException = "roomName must begin with a '/'";
+
+            expect(() => {
+                roomService.getRoom({ roomName: "room-should-begin-with-slash" });
+            }).to.throw(expectedException);
+        });
+
+        it("should add the room name to the response body if response code is 2xx", () => {
+            const data = {
+                test: "data",
+            };
+            const expectedObj = new Room(Object.assign({}, data, { roomName }));
+            organizationApiClient.request
+                .withArgs(uri, { method, params: defaultParams })
+                .resolves(new Response({ data }));
+
+            return roomService.getRoom({ roomName }).then((result) => {
+                expect(result).to.eql(expectedObj);
+            });
+        });
+
+        it("should call request with correct params when called with fields", () => {
+            const fields = ["some-field"];
+            organizationApiClient.request.resolves({ data: {} });
+
+            return roomService.getRoom({ roomName, fields }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(uri, {
+                    method,
+                    params: { fields: fields[0], ...defaultParams },
+                });
+            });
+        });
+
+        it("should set meeting if meeting is returned", () => {
+            const mockMeeting = {
+                meetingId: "10",
+                roomName: "/some-room-name",
+                roomUrl: "some-room-url",
+                startDate: new Date(),
+                endDate: new Date(),
+                hostRoomUrl: "some-host-room-url",
+                viewerRoomUrl: null,
+            };
+            const data = {
+                meeting: toJson(mockMeeting),
+            };
+            const expectedObj = new Room({ roomName, meeting: new Meeting(mockMeeting) });
+            organizationApiClient.request.resolves(new Response({ data }));
+
+            return roomService.getRoom({ roomName }).then((result) => {
+                expect(result).to.eql(expectedObj);
+            });
+        });
+
+        it("should set isBanned to true if response code is 400 with error Banned room", async () => {
+            const expectedObj = new Room({
+                roomName,
+                isBanned: true,
+            });
+            organizationApiClient.request
+                .withArgs(uri, { method, params: { includeOnlyLegacyRoomType: "false" } })
+                .returns(
+                    Promise.reject(
+                        new Response({
+                            status: 400,
+                            data: {
+                                error: "Banned room",
+                            },
+                        })
+                    )
+                );
+
+            const result = await roomService.getRoom({ roomName });
+
+            expect(result).to.eql(expectedObj);
+        });
+
+        it("should return deduced room object if response code is 404", async () => {
+            organizationApiClient.request.rejects(new Response({ status: 404 }));
+
+            const result = await roomService.getRoom({ roomName });
+
+            expect(result).to.eql(
+                new Room({
+                    roomName,
+                    isClaimed: false,
+                    legacyRoomType: "free",
+                    mode: "normal",
+                    product: {
+                        categoryName: "personal_free",
+                    },
+                    type: "personal",
+                })
+            );
+        });
+
+        it("should return error message if response code is not 2xx, 403 or 404 and data.error exists", () => {
+            const data = {
+                error: "Some error message",
+            };
+
+            organizationApiClient.request.rejects(new Response({ status: 405, data }));
+
+            return expect(roomService.getRoom({ roomName })).to.be.rejectedWith(Error, data.error);
+        });
+
+        it("should return error message if response code is not 2xx, 403 or 404 and data.error does not exist", () => {
+            const errorMessage = "Could not fetch room information";
+
+            organizationApiClient.request.rejects(new Response({ status: 505, data: null }));
+
+            return expect(roomService.getRoom({ roomName })).to.be.rejectedWith(Error, errorMessage);
+        });
+    });
+
+    describe("claimRoom", () => {
+        const url = "/room/claim";
+        const method = "POST";
+        const type = "personal";
+        const roomName = "/some-random-name";
+
+        beforeEach(() => {
+            organizationApiClient.request.resolves();
+        });
+
+        itShouldThrowIfInvalid("roomName", () => roomService.claimRoom({ type }));
+        itShouldThrowIfInvalid("type", () => roomService.claimRoom({ roomName }));
+
+        it("should reject with error containing the error message if available", () => {
+            const expectedError = "some error";
+            organizationApiClient.request.rejects(
+                new Response({
+                    status: 500,
+                    data: {
+                        error: expectedError,
+                    },
+                })
+            );
+
+            const promise = roomService.claimRoom({ roomName, type });
+
+            return expect(promise).to.eventually.be.rejectedWith(Error, expectedError);
+        });
+
+        it("should reject with error 'Failed to claim room' if none is provided by the server", () => {
+            organizationApiClient.request.rejects(
+                new Response({
+                    status: 500,
+                    data: {},
+                })
+            );
+
+            const promise = roomService.claimRoom({ roomName, type });
+
+            return expect(promise).to.eventually.be.rejectedWith(Error, "Failed to claim room");
+        });
+
+        it("should call request with correct params if all arguments have been provided", () => {
+            const isLocked = true;
+
+            roomService.claimRoom({ roomName, type, isLocked });
+
+            expect(organizationApiClient.request).to.have.been.calledWithExactly(url, {
+                method,
+                data: { roomName, type, isLocked },
+            });
+        });
+
+        it("should call request with correct params if isLock is not provided", () => {
+            roomService.claimRoom({ roomName, type });
+
+            expect(organizationApiClient.request).to.have.been.calledWithExactly(url, {
+                method,
+                data: { roomName, type },
+            });
+        });
+    });
+
+    describe("unclaimRoom", () => {
+        const roomName = "/some-room-name";
+
+        itShouldThrowIfInvalid("roomName", () => {
+            roomService.unclaimRoom(undefined);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.unclaimRoom(roomName);
+            }
+        );
+
+        it("should call request the expected parameters", () => {
+            organizationApiClient.request.resolves(new Response({ status: 204 }));
+
+            const promise = roomService.unclaimRoom(roomName);
+
+            return promise.then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(
+                    `/room/${encodeURIComponent(roomName.substring(1))}`,
+                    {
+                        method: "DELETE",
+                    }
+                );
+            });
+        });
+
+        it("should resolve with undefined on success", async () => {
+            organizationApiClient.request.resolves(new Response({ status: 204 }));
+
+            const result = await roomService.unclaimRoom(roomName);
+
+            expect(result).to.eql(undefined);
+        });
+    });
+
+    describe("renameRoom", () => {
+        const roomName = "/foo";
+        const encodedRoomName = encodeURIComponent(roomName.substring(1));
+        const url = `/room/${encodedRoomName}/roomName`;
+        const newRoomName = "/bar";
+        const data = { newRoomName };
+
+        it("should call apiClient.request with the expected parameters", () => {
+            organizationApiClient.request.resolves();
+
+            return roomService.renameRoom({ roomName, newRoomName }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, { method: "PUT", data });
+            });
+        });
+
+        it("should be resolved if apiClient.request resolves", async () => {
+            organizationApiClient.request.resolves();
+
+            const result = await roomService.renameRoom({ roomName, newRoomName });
+
+            expect(result).to.eql(undefined);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.renameRoom({ roomName, newRoomName });
+            }
+        );
+    });
+
+    describe("changeMode", () => {
+        const roomName = "/foo";
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+        const url = `/room/${encodedDisplayName}/mode`;
+        const method = "PUT";
+        const mode = "group";
+        const data = { mode };
+
+        it("should call apiClient.request with the expected parameters", () => {
+            organizationApiClient.request.resolves();
+
+            return roomService.changeMode({ roomName, mode }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, { method, data });
+            });
+        });
+
+        it("should be resolved if apiClient.request resolves", async () => {
+            organizationApiClient.request.resolves();
+
+            const result = await roomService.changeMode({ roomName, mode });
+
+            expect(result).to.eql(undefined);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.changeMode({ roomName, mode });
+            }
+        );
+    });
+
+    describe("getRoomPermissions", () => {
+        const roomName = "/some-room-name";
+        const permissions = {};
+        const limits = {
+            maxNumberOfClaimedRooms: null,
+        };
+
+        const roomPermissionsPayload = {
+            permissions,
+            limits,
+        };
+
+        itShouldThrowIfInvalid("roomName", () => {
+            roomService.getRoomPermissions();
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.getRoomPermissions(roomName);
+            }
+        );
+
+        describe("when roomKey is not provided", () => {
+            it("should call request the expected parameters", () => {
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: roomPermissionsPayload,
+                    })
+                );
+
+                const promise = roomService.getRoomPermissions(roomName);
+
+                return promise.then(() => {
+                    expect(organizationApiClient.request).to.have.been.calledWithExactly(
+                        `/room/${encodeURIComponent(roomName.substring(1))}/permissions`,
+                        {
+                            method: "GET",
+                        }
+                    );
+                });
+            });
+
+            it("should resolve with undefined on success", async () => {
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: roomPermissionsPayload,
+                    })
+                );
+
+                const result = await roomService.getRoomPermissions(roomName);
+
+                expect(result).to.eql(roomPermissionsPayload);
+            });
+        });
+
+        describe("when roomKey is provided", () => {
+            let roomKey;
+
+            beforeEach(() => {
+                roomKey = "some room key";
+            });
+
+            it("should call request the expected parameters", () => {
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: roomPermissionsPayload,
+                    })
+                );
+
+                const promise = roomService.getRoomPermissions(roomName, { roomKey });
+
+                return promise.then(() => {
+                    expect(organizationApiClient.request).to.have.been.calledWithExactly(
+                        `/room/${encodeURIComponent(roomName.substring(1))}/permissions`,
+                        {
+                            method: "GET",
+                            headers: {
+                                "X-Whereby-Room-Key": roomKey,
+                            },
+                        }
+                    );
+                });
+            });
+
+            it("should resolve with undefined on success", async () => {
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: roomPermissionsPayload,
+                    })
+                );
+
+                const result = await roomService.getRoomPermissions(roomName, { roomKey });
+
+                expect(result).to.eql(roomPermissionsPayload);
+            });
+        });
+    });
+
+    describe("getRoomMetrics", () => {
+        const roomName = "/some-room-name";
+        const metrics = "totalMeetings";
+        const roomMetricsPayload = { roomName, metrics };
+
+        itShouldThrowIfInvalid("roomName", () => {
+            roomService.getRoomMetrics({});
+        });
+
+        itShouldThrowIfInvalid("metrics", () => {
+            roomService.getRoomMetrics({ roomName });
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.getRoomMetrics(roomMetricsPayload);
+            }
+        );
+
+        describe("when valid payload provided", () => {
+            it("should call request the expected parameters", () => {
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {},
+                    })
+                );
+
+                const promise = roomService.getRoomMetrics(roomMetricsPayload);
+
+                return promise.then(() => {
+                    expect(organizationApiClient.request).to.have.been.calledWithExactly(
+                        `/room/${encodeURIComponent(roomName.substring(1))}/metrics`,
+                        {
+                            method: "GET",
+                            params: { metrics, from: undefined, to: undefined },
+                        }
+                    );
+                });
+            });
+
+            it("should call request the expected parameters when including from and to", () => {
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: {},
+                    })
+                );
+
+                const from = new Date().toISOString();
+                const to = new Date().toISOString();
+                const promise = roomService.getRoomMetrics({ ...roomMetricsPayload, from, to });
+
+                return promise.then(() => {
+                    expect(organizationApiClient.request).to.have.been.calledWithExactly(
+                        `/room/${encodeURIComponent(roomName.substring(1))}/metrics`,
+                        {
+                            method: "GET",
+                            params: { metrics, from, to },
+                        }
+                    );
+                });
+            });
+
+            it("should resolve with response data on success", async () => {
+                const responseData = Symbol();
+                organizationApiClient.request.resolves(
+                    new Response({
+                        status: 200,
+                        data: responseData,
+                    })
+                );
+
+                const result = await roomService.getRoomMetrics(roomMetricsPayload);
+
+                expect(result).to.eql(responseData);
+            });
+        });
+    });
+
+    describe("updatePreferences", () => {
+        const roomName = "/foo";
+        let preferences;
+
+        beforeEach(() => {
+            preferences = { bar: Symbol() };
+        });
+
+        itShouldThrowIfInvalid("roomName", () => roomService.updatePreferences({ preferences }));
+        itShouldThrowIfInvalid("preferences", () => roomService.updatePreferences({ roomName }));
+
+        it("should call apiClient.request with the expected parameters", () => {
+            const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+            const url = `/room/${encodedDisplayName}/preferences`;
+            organizationApiClient.request.resolves();
+
+            return roomService.updatePreferences({ roomName, preferences }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, {
+                    method: "PATCH",
+                    data: preferences,
+                });
+            });
+        });
+
+        it("should be resolved if apiClient.request resolves", async () => {
+            organizationApiClient.request.resolves();
+
+            const result = await roomService.updatePreferences({ roomName, preferences });
+
+            expect(result).to.eql(undefined);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.updatePreferences({ roomName, preferences });
+            }
+        );
+    });
+
+    describe("updateProtectedPreferences", () => {
+        const roomName = "/foo";
+        let preferences;
+
+        beforeEach(() => {
+            preferences = { bar: Symbol() };
+        });
+
+        itShouldThrowIfInvalid("roomName", () => roomService.updateProtectedPreferences({ preferences }));
+        itShouldThrowIfInvalid("preferences", () => roomService.updateProtectedPreferences({ roomName }));
+
+        it("should call apiClient.request with the expected parameters", () => {
+            const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+            const url = `/room/${encodedDisplayName}/protected-preferences`;
+            organizationApiClient.request.resolves();
+
+            return roomService.updateProtectedPreferences({ roomName, preferences }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, {
+                    method: "PATCH",
+                    data: preferences,
+                });
+            });
+        });
+
+        it("should be resolved if apiClient.request resolves", async () => {
+            organizationApiClient.request.resolves();
+
+            const result = await roomService.updateProtectedPreferences({ roomName, preferences });
+
+            expect(result).to.eql(undefined);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.updateProtectedPreferences({ roomName, preferences });
+            }
+        );
+    });
+
+    describe("changeType", () => {
+        const roomName = "/foo";
+        const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+        const url = `/room/${encodedDisplayName}/type`;
+        const method = "PUT";
+        const type = "personal";
+        const data = { type };
+
+        it("should call apiClient.request with the expected parameters", () => {
+            organizationApiClient.request.resolves();
+
+            return roomService.changeType({ roomName, type }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, { method, data });
+            });
+        });
+
+        it("should be resolved if apiClient.request resolves", async () => {
+            organizationApiClient.request.resolves();
+
+            const result = await roomService.changeType({ roomName, type });
+
+            expect(result).to.eql(undefined);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.changeType({ roomName, type });
+            }
+        );
+    });
+
+    describe("getForestSocialImage", () => {
+        const roomName = "/foo";
+        const count = 24;
+        const imageUrl = Symbol();
+
+        itShouldThrowIfInvalid("roomName", () => roomService.getForestSocialImage({ count }));
+        itShouldThrowIfInvalid("count", () => roomService.getForestSocialImage({ roomName }));
+
+        it("should call apiClient.request with the expected parameters", () => {
+            const encodedDisplayName = encodeURIComponent(roomName.substring(1));
+            const url = `/room/${encodedDisplayName}/forest-social-image/${count}`;
+            organizationApiClient.request.resolves({ data: { imageUrl } });
+
+            return roomService.getForestSocialImage({ roomName, count }).then(() => {
+                expect(organizationApiClient.request).to.have.been.calledWithExactly(url, {
+                    method: "GET",
+                });
+            });
+        });
+
+        it("should resolve with imageUrl if apiClient.request resolves", async () => {
+            organizationApiClient.request.resolves({ data: { imageUrl } });
+
+            const result = await roomService.getForestSocialImage({ roomName, count });
+
+            expect(result).to.eql(imageUrl);
+        });
+
+        itShouldRejectIfApiClientRejects(
+            () => organizationApiClient,
+            () => {
+                return roomService.getForestSocialImage({ roomName, count });
+            }
+        );
+    });
+});

--- a/src/lib/api/test/ApiClient.spec.ts
+++ b/src/lib/api/test/ApiClient.spec.ts
@@ -1,0 +1,139 @@
+import axios from "axios";
+import ApiClient from "../ApiClient";
+import Credentials from "../Credentials";
+import Response from "../Response";
+import { itShouldThrowIfInvalid } from "./helpers";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const baseUrl = "https://localhost:8090";
+const credentials = new Credentials("12345", "67890");
+
+describe("ApiClient", () => {
+    describe("constructor", () => {
+        it("should not throw an error if no constructor params are passed through", () => {
+            expect(() => new ApiClient()).not.toThrowError();
+        });
+
+        //@ts-expect-error
+        itShouldThrowIfInvalid("baseUrl", () => new ApiClient({ baseUrl: null }));
+        //@ts-expect-error
+        itShouldThrowIfInvalid("fetchDeviceCredentials", () => new ApiClient({ fetchDeviceCredentials: null }));
+    });
+
+    describe("request", () => {
+        let fetchDeviceCredentialsMock: jest.Mock;
+        let apiClient: ApiClient;
+
+        beforeEach(() => {
+            mockedAxios.request.mockResolvedValue(new Response());
+            fetchDeviceCredentialsMock = jest.fn().mockResolvedValueOnce(credentials);
+            apiClient = new ApiClient({
+                baseUrl,
+                fetchDeviceCredentials: fetchDeviceCredentialsMock,
+            });
+        });
+
+        afterEach(() => {
+            mockedAxios.request.mockClear();
+        });
+
+        //@ts-expect-error
+        itShouldThrowIfInvalid("url", () => apiClient.request(null, {}));
+
+        // `url` is required to begin with a `/`
+        it('should throw if `url` does not begin with a "/"', () => {
+            expect(() => apiClient.request("some-url", {})).toThrowError();
+        });
+
+        //@ts-expect-error
+        itShouldThrowIfInvalid("fetchDeviceCredentials", () => new ApiClient({ fetchDeviceCredentials: null }));
+
+        it("should run `this.fetchDeviceCredentials`", () => {
+            const url = "/some/path";
+            const fetchOptions = {};
+
+            apiClient.request(url, fetchOptions);
+
+            expect(fetchDeviceCredentialsMock).toBeCalledTimes(1);
+        });
+
+        it("should return the correct Response value with the correct data if fulfilled", async () => {
+            const responseBaseUrl = "www.website.com";
+            const url = "/some/path";
+            const method = "post";
+            const headers = {
+                type: "jif",
+            };
+            const data = { some: "data" };
+            const status = 200;
+            const statusText = "some status text";
+            const response = {
+                data,
+                headers,
+                method,
+                status,
+                statusText,
+                config: {
+                    url,
+                    baseURL: responseBaseUrl,
+                },
+            };
+            const expectedResponse = new Response({
+                data,
+                headers,
+                status: response.status,
+                statusText: response.statusText,
+                url: `${responseBaseUrl}${url}`,
+            });
+            mockedAxios.request.mockResolvedValueOnce(response);
+
+            const result = await apiClient.request(url, {});
+
+            expect(result).toEqual(expectedResponse);
+        });
+
+        it("should throw an error if rejected with no `response` object", async () => {
+            const url = "/some/path";
+            const data = {};
+            mockedAxios.request.mockRejectedValue(new Response({ status: 404, data }));
+
+            await expect(apiClient.request(url, {})).rejects.toThrow("Could not make the request.");
+        });
+
+        it("should return the correct Response value with the correct data if rejected", async () => {
+            const responseBaseUrl = "www.website.com";
+            const url = "/some/path";
+            const method = "post";
+            const headers = {
+                type: "jif",
+            };
+            const data = { some: "data" };
+            const status = 200;
+            const statusText = "some status text";
+            const response = {
+                data,
+                headers,
+                method,
+                status,
+                statusText,
+                config: {
+                    url,
+                    baseURL: responseBaseUrl,
+                },
+            };
+            const expectedResponse = new Response({
+                data,
+                headers,
+                status: response.status,
+                statusText: response.statusText,
+                url: `${responseBaseUrl}${url}`,
+            });
+            mockedAxios.request.mockRejectedValue({ response });
+
+            await expect(apiClient.request(url, {})).rejects.toEqual(expectedResponse);
+        });
+    });
+});

--- a/src/lib/api/test/HttpClient.spec.ts
+++ b/src/lib/api/test/HttpClient.spec.ts
@@ -1,0 +1,120 @@
+import axios from "axios";
+import HttpClient from "../HttpClient";
+import Response from "../Response";
+import { itShouldThrowIfInvalid } from "./helpers";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const baseUrl = "https://localhost:8090";
+
+describe("HttpClient", () => {
+    describe("constructor", () => {
+        it("should set `baseUrl` param as class properties", () => {
+            const httpClient = new HttpClient({
+                baseUrl,
+            });
+
+            expect(httpClient._baseUrl).toBe(baseUrl);
+        });
+
+        //@ts-expect-error
+        itShouldThrowIfInvalid("baseUrl", () => new HttpClient({ baseUrl: null }));
+    });
+
+    describe("request", () => {
+        let httpClient: HttpClient;
+
+        beforeEach(() => {
+            httpClient = new HttpClient({
+                baseUrl,
+            });
+            mockedAxios.request.mockClear();
+        });
+
+        //@ts-expect-error
+        itShouldThrowIfInvalid("url", () => httpClient.request(null, {}));
+
+        // `url` is required to begin with a `/`
+        it('should throw if `url` does not begin with a "/"', () => {
+            expect(() => httpClient.request("some-url", {})).toThrowError();
+        });
+
+        it("should return the correct Response value with the correct data if fulfilled", async () => {
+            const responseBaseUrl = "www.website.com";
+            const url = "/some/path";
+            const method = "post";
+            const headers = {
+                type: "jif",
+            };
+            const data = { some: "data" };
+            const status = 200;
+            const statusText = "some status text";
+            const response = {
+                data,
+                headers,
+                method,
+                status,
+                statusText,
+                config: {
+                    url,
+                    baseURL: responseBaseUrl,
+                },
+            };
+            const expectedResponse = new Response({
+                data,
+                headers,
+                status: response.status,
+                statusText: response.statusText,
+                url: `${responseBaseUrl}${url}`,
+            });
+            mockedAxios.request.mockResolvedValue(response);
+
+            const result = await httpClient.request(url, {});
+
+            expect(result).toEqual(expectedResponse);
+        });
+
+        it("should throw an error if rejected with no `response` object", async () => {
+            const url = "/some/path";
+            const data = {};
+            mockedAxios.request.mockRejectedValue(new Response({ status: 404, data }));
+
+            await expect(httpClient.request(url, {})).rejects.toThrow("Could not make the request.");
+        });
+
+        it("should return the correct Response value with the correct data if rejected", async () => {
+            const responseBaseUrl = "www.website.com";
+            const url = "/some/path";
+            const method = "post";
+            const headers = {
+                type: "jif",
+            };
+            const data = { some: "data" };
+            const status = 200;
+            const statusText = "some status text";
+            const response = {
+                data,
+                headers,
+                method,
+                status,
+                statusText,
+                config: {
+                    url,
+                    baseURL: responseBaseUrl,
+                },
+            };
+            const expectedResponse = new Response({
+                data,
+                headers,
+                status: response.status,
+                statusText: response.statusText,
+                url: `${responseBaseUrl}${url}`,
+            });
+            mockedAxios.request.mockRejectedValue({ response });
+
+            await expect(httpClient.request(url, {})).rejects.toEqual(expectedResponse);
+        });
+    });
+});

--- a/src/lib/api/test/MultipartHttpClient.spec.ts
+++ b/src/lib/api/test/MultipartHttpClient.spec.ts
@@ -1,0 +1,145 @@
+// @ts-nocheck
+import axios from "axios";
+import MultipartHttpClient from "../MultipartHttpClient";
+import Response from "../Response";
+import HttpClient from "../HttpClient";
+import { itShouldThrowIfInvalid } from "./helpers";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+class FormData {
+    values: Record<string, string>;
+    constructor() {
+        this.values = {};
+    }
+    append(key, value) {
+        this.values[key] = value;
+    }
+}
+
+describe("MultipartHttpClient", () => {
+    describe("dataToFormData", () => {
+        let originalFormData;
+        beforeAll(() => {
+            originalFormData = global.FormData;
+            global.FormData = FormData;
+        });
+
+        afterAll(() => {
+            global.FormData = originalFormData;
+        });
+
+        itShouldThrowIfInvalid("data", () => {
+            MultipartHttpClient.dataToFormData(null);
+        });
+
+        it("should return empty FormData if provided object is empty", () => {
+            const formData = MultipartHttpClient.dataToFormData({});
+
+            expect(formData).toEqual(new FormData());
+        });
+
+        it("should return FormData where each key and value is added", () => {
+            const expectedFormData = new FormData();
+            expectedFormData.append("a", "some a");
+            expectedFormData.append("some other key", "some other key value");
+
+            const formData = MultipartHttpClient.dataToFormData({
+                a: "some a",
+                "some other key": "some other key value",
+            });
+
+            expect(formData).toEqual(expectedFormData);
+        });
+    });
+
+    describe("constructor", () => {
+        itShouldThrowIfInvalid("httpClient", () => new MultipartHttpClient({ httpClient: undefined }));
+    });
+
+    describe("request", () => {
+        let httpClient: HttpClient;
+        let multipartHttpClient: MultipartHttpClient;
+        const uri = "/api";
+        const baseUrl = "https://localhost:8090";
+
+        beforeEach(() => {
+            httpClient = new HttpClient({
+                baseUrl,
+            });
+            mockedAxios.request.mockClear();
+            multipartHttpClient = new MultipartHttpClient({ httpClient });
+        });
+
+        it("should reject with the response from httpClient if rejected", async () => {
+            const response = new Response({ status: 400 });
+            mockedAxios.request.mockRejectedValueOnce(response);
+
+            await expect(multipartHttpClient.request(uri, { method: "GET" })).rejects.toThrow(
+                "Could not make the request."
+            );
+        });
+
+        it("should resolve with the response from httpClient if resolved", async () => {
+            const response = new Response({ status: 204 });
+            mockedAxios.request.mockResolvedValueOnce(response);
+
+            const result = await multipartHttpClient.request(uri, { method: "GET" });
+
+            expect(result).toEqual(response);
+        });
+
+        it("should call httpClient with merged options object that handles form parameters", async () => {
+            const data = {
+                someField: "someValue",
+            };
+            const options = {
+                method: "POST",
+                data,
+                headers: {
+                    accept: "text/xml",
+                    "Content-Type": "text/xml",
+                },
+            };
+            const response = new Response({ status: 204 });
+            mockedAxios.request.mockResolvedValueOnce(response);
+
+            await multipartHttpClient.request(uri, options);
+
+            expect(mockedAxios.request).toBeCalledWith({
+                baseURL: baseUrl,
+                method: "POST",
+                data,
+                headers: {
+                    accept: "text/xml",
+                    "Content-Type": undefined,
+                },
+                transformRequest: MultipartHttpClient.dataToFormData,
+                url: uri,
+            });
+        });
+
+        it("should call httpClient with contentType undefined even if it is provided", async () => {
+            const contentType = "overridenValue";
+            const response = new Response({ status: 204 });
+            mockedAxios.request.mockResolvedValueOnce(response);
+
+            await multipartHttpClient.request(uri, {
+                headers: {
+                    "Content-Type": contentType,
+                },
+            });
+
+            expect(mockedAxios.request).toBeCalledWith({
+                baseURL: baseUrl,
+                headers: {
+                    "Content-Type": undefined,
+                },
+                transformRequest: MultipartHttpClient.dataToFormData,
+                url: uri,
+            });
+        });
+    });
+});

--- a/src/lib/api/test/OrganizationApiClient.spec.ts
+++ b/src/lib/api/test/OrganizationApiClient.spec.ts
@@ -1,0 +1,132 @@
+import ApiClient from "../ApiClient";
+import Response from "../Response";
+import OrganizationApiClient from "../OrganizationApiClient";
+import { itShouldThrowIfInvalid } from "./helpers";
+import { HttpClientRequestConfig } from "../HttpClient";
+
+jest.mock("../ApiClient");
+
+describe("OrganizationApiClient", () => {
+    let apiClient: jest.Mocked<ApiClient>;
+
+    beforeEach(() => {
+        apiClient = new ApiClient() as jest.Mocked<ApiClient>;
+    });
+
+    describe("constructor", () => {
+        //@ts-expect-error
+        itShouldThrowIfInvalid("apiClient", () => new OrganizationApiClient({ apiClient: null }));
+        itShouldThrowIfInvalid(
+            "fetchOrganization",
+            () =>
+                new OrganizationApiClient({
+                    apiClient,
+                    //@ts-expect-error
+                    fetchOrganization: null,
+                })
+        );
+    });
+
+    function testRequestMethod(requestMethodName: "request" | "requestMultipart") {
+        describe(requestMethodName, () => {
+            let fetchOrganization: jest.Mock;
+            let organizationApiClient: OrganizationApiClient;
+            let apiRequestMethod: jest.MockInstance<Promise<Response>, [url: string, options: HttpClientRequestConfig]>;
+            let organizationApiRequestMethod: (
+                url: string,
+                config: HttpClientRequestConfig
+            ) => Promise<Response>;
+
+            beforeEach(() => {
+                fetchOrganization = jest.fn();
+                organizationApiClient = new OrganizationApiClient({
+                    apiClient,
+                    fetchOrganization,
+                });
+
+                apiRequestMethod = apiClient[requestMethodName];
+
+                organizationApiRequestMethod = organizationApiClient[requestMethodName].bind(organizationApiClient);
+            });
+
+            //@ts-expect-error
+            itShouldThrowIfInvalid("url", () => organizationApiRequestMethod(null, {}));
+
+            // `url` is required to begin with a `/`
+            it('should throw if `url` does not begin with a "/"', () => {
+                expect(() => organizationApiRequestMethod("some-url", {})).toThrowError();
+            });
+
+            it("should run `this.fetchOrganization`", () => {
+                const url = "/some/path";
+                const fetchOptions = {};
+                fetchOrganization.mockResolvedValue(null);
+
+                organizationApiRequestMethod(url, fetchOptions);
+
+                expect(fetchOrganization).toBeCalledTimes(1);
+            });
+
+            describe("when no organization is returned", () => {
+                beforeEach(() => {
+                    fetchOrganization.mockResolvedValue(null);
+                });
+
+                it("should call the apiClient without organization prefix", () => {
+                    const url = "/some/path";
+                    const opts = { headers: { blah: "blah" } };
+                    apiRequestMethod.mockResolvedValue(new Response());
+
+                    const promise = organizationApiRequestMethod(url, opts);
+
+                    return promise.then(() => {
+                        expect(apiRequestMethod).toBeCalledWith(url, opts);
+                    });
+                });
+
+                it("should return the response from the apiClient", async () => {
+                    const url = "/some/path";
+                    const options = { headers: { blah: "blah" } };
+                    const response = new Response({ status: 204 });
+                    apiRequestMethod.mockResolvedValue(response);
+
+                    const result = await organizationApiRequestMethod(url, options);
+
+                    expect(result).toEqual(response);
+                });
+            });
+
+            describe("when an organization is returned", () => {
+                const organizationId = 707;
+                const options = { headers: { blah: "blah" } };
+                beforeEach(() => {
+                    fetchOrganization.mockResolvedValue({ organizationId });
+                });
+
+                it("should call the apiClient without organization prefix", () => {
+                    const url = "/some/path";
+                    apiRequestMethod.mockResolvedValue(new Response());
+
+                    const promise = organizationApiRequestMethod(url, options);
+
+                    return promise.then(() => {
+                        expect(apiRequestMethod).toBeCalledWith(`/organizations/${organizationId}` + url, options);
+                    });
+                });
+
+                it("should return the response from the apiClient", async () => {
+                    const url = "/some/path";
+                    const response = new Response({ status: 204 });
+                    apiRequestMethod.mockResolvedValue(response);
+
+                    const result = await organizationApiRequestMethod(url, options);
+
+                    expect(result).toEqual(response);
+                });
+            });
+        });
+    }
+
+    testRequestMethod("request");
+    testRequestMethod("requestMultipart");
+});

--- a/src/lib/api/test/extractUtils.spec.ts
+++ b/src/lib/api/test/extractUtils.spec.ts
@@ -1,0 +1,357 @@
+import {
+    extractArray,
+    extractArrayOfJson,
+    extractBoolean,
+    extractDate,
+    extractJson,
+    extractJsonWithTransform,
+    extractNullOrDate,
+    extractNullOrString,
+    extractNumber,
+    Extractor,
+    extractString,
+    nullOrTransform,
+    Transformer,
+} from "../extractUtils";
+import assert from "assert";
+import { Json } from "../Response";
+import { assertString } from "../parameterAssertUtils";
+type User = { name: string; eyeColor: string | null; age: number; dob: Date };
+function toUser(data: Json): User {
+    return {
+        name: extractString(data, "name"),
+        eyeColor: extractNullOrString(data, "eyeColor"),
+        age: extractNumber(data, "age"),
+        dob: extractDate(data, "dob"),
+    };
+}
+
+type InvalidValue = { desc: string; value?: Json; expectedError?: string | RegExp };
+type ValidValue = { desc: string; value?: Json; expected: unknown };
+function itShouldThrowForValues(extract: Extractor<unknown>, values: ReadonlyArray<InvalidValue>) {
+    assert.ok(typeof extract === "function", "extract must be a function");
+
+    values.forEach(({ desc, value, expectedError }) => {
+        it(`should throw for ${desc}`, () => {
+            expect(() => {
+                extract({ ...(value !== undefined && { prop: value }) }, "prop");
+            }).toThrowError(expectedError || /prop<.*> is required/);
+        });
+    });
+}
+
+function itShouldExtractForValues(extract: Extractor<unknown>, values: ReadonlyArray<ValidValue>) {
+    values.forEach(({ desc, value, expected }) => {
+        it(`should extract ${desc} correctly`, () => {
+            const result = extract({ ...(value !== undefined && { prop: value }) }, "prop");
+
+            expect(result).toEqual(expected);
+        });
+    });
+}
+
+function testExtract(
+    extract: Extractor<unknown>,
+    {
+        invalidValues,
+        validValues,
+    }: { invalidValues: ReadonlyArray<InvalidValue>; validValues: ReadonlyArray<ValidValue> }
+) {
+    itShouldThrowForValues(extract, invalidValues);
+    itShouldExtractForValues(extract, validValues);
+    [null, undefined, "string", 12].forEach((value) => {
+        it(`should throw for ${value}`, () => {
+            expect(() => {
+                //@ts-expect-error
+                extract(value, "prop");
+            }).toThrowError(/prop<.*> is required|data must be a record/);
+        });
+    });
+}
+
+describe("extractUtils", () => {
+    const nullValues: Array<ValidValue> = [
+        { desc: "null", value: null, expected: null },
+        { desc: "null", value: undefined, expected: null },
+    ];
+    const invalidNullValues: Array<InvalidValue> = [
+        { desc: "null", value: null },
+        { desc: "null", value: undefined },
+    ];
+    const validStringValues: ReadonlyArray<ValidValue> = [
+        { desc: "string", value: "some-string", expected: "some-string" },
+    ];
+    const invalidStringValues: ReadonlyArray<InvalidValue> = [
+        { desc: "boolean", value: true },
+        { desc: "number", value: 12 },
+        { desc: "empty object", value: {} },
+        { desc: "empty array", value: [] },
+    ];
+
+    describe("extractBoolean", () => {
+        testExtract(extractBoolean, {
+            validValues: [
+                { desc: "boolean - true", value: true, expected: true },
+                { desc: "boolean - false", value: false, expected: false },
+            ],
+            invalidValues: (
+                [
+                    { desc: "number", value: 0 },
+                    { desc: "string", value: "some-string" },
+                    { desc: "string - true", value: "true" },
+                    { desc: "string - false", value: "false" },
+                    { desc: "empty object", value: {} },
+                    { desc: "empty array", value: [] },
+                ] as Array<InvalidValue>
+            ).concat(invalidNullValues),
+        });
+    });
+
+    describe("extractString", () => {
+        testExtract(extractString, {
+            validValues: validStringValues,
+            invalidValues: invalidStringValues.concat(nullValues),
+        });
+    });
+
+    describe("extractNullOrString", () => {
+        testExtract(extractNullOrString, {
+            validValues: validStringValues.concat(nullValues),
+            invalidValues: invalidStringValues,
+        });
+    });
+
+    describe("extractNumber", () => {
+        testExtract(extractNumber, {
+            validValues: [{ desc: "number", value: 12, expected: 12 }],
+            invalidValues: invalidNullValues.concat([
+                { desc: "boolean", value: true },
+                { desc: "string", value: "some-string" },
+                { desc: "empty object", value: {} },
+                { desc: "empty array", value: [] },
+            ]),
+        });
+    });
+
+    const validDate = new Date("2022-01-01");
+    const validDateValues: Array<ValidValue> = [{ desc: "date", value: validDate.toISOString(), expected: validDate }];
+    const invalidDateValues: Array<InvalidValue> = [
+        { desc: "boolean", value: true },
+        { desc: "number", value: 12 },
+        { desc: "invalid date string", value: "some-string", expectedError: "Invalid date for some-string" },
+        { desc: "empty object", value: {} },
+        { desc: "empty array", value: [] },
+    ];
+    describe("extractDate", () => {
+        testExtract(extractDate, {
+            validValues: validDateValues,
+            invalidValues: invalidNullValues.concat(invalidDateValues),
+        });
+    });
+
+    describe("extractNullOrDate", () => {
+        testExtract(extractNullOrDate, {
+            validValues: validDateValues.concat(nullValues),
+            invalidValues: invalidDateValues,
+        });
+    });
+
+    const invalidArrayValues: ReadonlyArray<InvalidValue> = [
+        { desc: "boolean", value: true },
+        { desc: "number", value: 12 },
+        { desc: "string", value: "some-string" },
+        { desc: "empty object", value: {} },
+    ];
+
+    describe("extractArrayOfJson", () => {
+        testExtract(extractArrayOfJson, {
+            validValues: [
+                { desc: "empty array", value: [], expected: [] },
+                { desc: "array with multiple elements", value: ["1", 2, true, {}], expected: ["1", 2, true, {}] },
+            ],
+            invalidValues: invalidArrayValues.concat(nullValues),
+        });
+    });
+
+    describe("extractArray", () => {
+        const invalidArrayValuesWithNullValues: ReadonlyArray<InvalidValue> = invalidArrayValues.concat(nullValues);
+        describe("with Identity transformer", () => {
+            testExtract((data, propertyName) => extractArray(data, propertyName, (json) => json), {
+                validValues: [
+                    { desc: "empty array", value: [], expected: [] },
+                    { desc: "array with multiple elements", value: ["1", 2, true, {}], expected: ["1", 2, true, {}] },
+                ],
+                invalidValues: invalidArrayValuesWithNullValues,
+            });
+        });
+
+        describe("with string transformer", () => {
+            const invalidArrayStringValues: ReadonlyArray<InvalidValue> = [
+                {
+                    desc: "array with number",
+                    value: [12],
+                    expectedError: "json<string> is required",
+                },
+                {
+                    desc: "array with object",
+                    value: [{}],
+                    expectedError: "json<string> is required",
+                },
+            ];
+            testExtract(
+                (data, propertyName) => extractArray(data, propertyName, (json) => assertString(json, "json")),
+                {
+                    validValues: [
+                        { desc: "empty array", value: [], expected: [] },
+                        { desc: "empty array", value: ["some-id"], expected: ["some-id"] },
+                    ],
+                    invalidValues: invalidArrayStringValues.concat(invalidArrayValuesWithNullValues),
+                }
+            );
+        });
+
+        describe("with complex object transformer", () => {
+            const dob = new Date("1965-01-01");
+            const invalidUserArray: ReadonlyArray<InvalidValue> = [
+                {
+                    desc: "array with invalid user object",
+                    value: [{}],
+                    expectedError: "name<string> is required",
+                },
+                {
+                    desc: "array with string",
+                    value: ["string"] as Json,
+                    expectedError: "data must be a record.",
+                },
+            ];
+            testExtract((data, propertyName) => extractArray(data, propertyName, toUser), {
+                validValues: [
+                    {
+                        desc: "only required",
+                        value: [
+                            { name: "some-name", age: 13, dob: dob.toISOString() },
+                            { name: "some-other-name", eyeColor: "brown", age: 40, dob: dob.toISOString() },
+                        ],
+                        expected: [
+                            { name: "some-name", age: 13, dob, eyeColor: null },
+                            { name: "some-other-name", eyeColor: "brown", age: 40, dob },
+                        ],
+                    },
+                    {
+                        desc: "empty array",
+                        value: [],
+                        expected: [],
+                    },
+                ],
+                invalidValues: invalidUserArray.concat(invalidArrayValuesWithNullValues),
+            });
+        });
+    });
+
+    const validJsonValues = nullValues.concat([
+        { desc: "empty object", value: {}, expected: {} },
+        {
+            desc: "object with multiple elements",
+            value: { string: "1", number: 2, boolean: true, object: {}, array: [] },
+            expected: { string: "1", number: 2, boolean: true, object: {}, array: [] },
+        },
+        { desc: "boolean", value: true, expected: true },
+        { desc: "number", value: 12, expected: 12 },
+        { desc: "string", value: "some-string", expected: "some-string" },
+        { desc: "empty array", value: [], expected: [] },
+    ]);
+    const invalidJsonValues: Array<InvalidValue> = [];
+    describe("extractJson", () => {
+        testExtract(extractJson, {
+            validValues: validJsonValues,
+            invalidValues: invalidJsonValues,
+        });
+    });
+
+    describe("extractJsonWithTransform", () => {
+        describe("with Identity transformer", () => {
+            testExtract((data, propertyName) => extractJsonWithTransform(data, propertyName, (json) => json), {
+                validValues: validJsonValues,
+                invalidValues: invalidJsonValues,
+            });
+        });
+
+        describe("with string transformer", () => {
+            testExtract(
+                (data, propertyName) =>
+                    extractJsonWithTransform(data, propertyName, (json) => extractString(json, "field")),
+                {
+                    validValues: [{ desc: "string field", value: { field: "some-field" }, expected: "some-field" }],
+                    invalidValues: [
+                        { desc: "boolean field", value: { field: true }, expectedError: "field<string> is required" },
+                        { desc: "null field", value: { field: null }, expectedError: "field<string> is required" },
+                    ],
+                }
+            );
+        });
+
+        describe("with complex object transformer", () => {
+            const dob = new Date("1965-01-01");
+            testExtract((data, propertyName) => extractJsonWithTransform(data, propertyName, toUser), {
+                validValues: [
+                    {
+                        desc: "only required",
+                        value: { name: "some-name", age: 13, dob: dob.toISOString() },
+                        expected: { name: "some-name", age: 13, dob, eyeColor: null },
+                    },
+                    {
+                        desc: "all properties",
+                        value: { name: "some-name", eyeColor: "brown", age: 40, dob: dob.toISOString() },
+                        expected: { name: "some-name", eyeColor: "brown", age: 40, dob },
+                    },
+                ],
+                invalidValues: [
+                    {
+                        desc: "empty object",
+                        value: {} as Json,
+                        expectedError: "name<string> is required",
+                    },
+                    {
+                        desc: "object without all fields",
+                        value: { name: "some name" } as Json,
+                        expectedError: "age<number> is required",
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("nullOrTransform", () => {
+        const intToString: Transformer<string> = (int: Json) => {
+            if (typeof int !== "number") {
+                throw new Error("unexpected type");
+            }
+
+            return int.toString();
+        };
+
+        const nullOrIntToString = nullOrTransform(intToString);
+
+        it("should return null if value is null", () => {
+            const value = nullOrIntToString(null);
+
+            expect(value).toEqual(null);
+        });
+
+        it("should return null if value is undefined", () => {
+            //@ts-expect-error
+            const value = nullOrIntToString(undefined);
+
+            expect(value).toEqual(null);
+        });
+
+        it(
+            "should return whatever value returned by the transformer if not null",
+            () => {
+                const value = nullOrIntToString(12);
+
+                expect(value).toEqual("12");
+            }
+        );
+    });
+});

--- a/src/lib/api/test/helpers.ts
+++ b/src/lib/api/test/helpers.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+
+import { Json } from "../Response";
+
+export const itShouldThrowIfInvalid = (missingPropertyName: string, func: () => void, regexMatcher?: RegExp): void => {
+    const testingNoArguments = !missingPropertyName;
+    const isOrAre = missingPropertyName[missingPropertyName.length - 1] === "s" ? "are" : "is";
+    const scenario = testingNoArguments ? "arguments are missing" : `${missingPropertyName} ${isOrAre} invalid`;
+    const expectedException = testingNoArguments
+        ? undefined
+        : regexMatcher || new RegExp(`${missingPropertyName}(<[\\w|]+>)? (is|are) required`);
+    it(`should throw if ${scenario}`, () => {
+        expect(() => {
+            func();
+        }).toThrowError(expectedException);
+    });
+};
+
+export const itShouldRejectIfApiClientRejects = (getApiClient: any, func: () => void): void => {
+    it("should fail if the request failed", async () => {
+        const error = new Error("some error");
+        getApiClient().request.mockRejectedValue(error);
+
+        await expect(func()).rejects.toThrow(error);
+    });
+};
+
+export const itShouldRejectIfMultipartRequestRejects = (getApiClient: any, func: () => void) => {
+    it("should fail if the requestMultipart failed", () => {
+        const error = new Error("some error");
+        getApiClient().requestMultipart.rejects(error);
+
+        const promise = func();
+
+        return expect(promise).to.eventually.be.rejected().toBe(error);
+    });
+};
+
+export function toJson(value: unknown): Json {
+    return JSON.parse(JSON.stringify(value));
+}

--- a/src/lib/api/test/parameterAssertUtils.spec.ts
+++ b/src/lib/api/test/parameterAssertUtils.spec.ts
@@ -1,0 +1,265 @@
+import assert from "assert";
+import {
+    assertBoolean,
+    assertRoomName,
+    assertNumber,
+    assertString,
+    assertInstanceOf,
+    assertOneOf,
+    assertRecord,
+} from "../parameterAssertUtils";
+
+function forEachObject(object: Record<string, unknown>, func: (value: unknown, key: string) => void) {
+    Object.keys(object).forEach((key) => func(object[key], key));
+}
+describe("parameterAssertUtils", () => {
+    function itShouldThrowForValues(testValues: Record<string, unknown>, test: (desc: string, value: unknown) => void) {
+        assert.ok(typeof test === "function", "test must be a function");
+
+        forEachObject(testValues, (value, descriptionOfValue) => {
+            it(`should throw for ${descriptionOfValue}`, () => {
+                test(descriptionOfValue, value);
+            });
+        });
+    }
+
+    describe("assertBoolean", () => {
+        itShouldThrowForValues(
+            {
+                string: "aaa",
+                "number as string": "12",
+                "boolean as string": "true",
+                null: null,
+                undefined: undefined, // eslint-disable-line object-shorthand
+                Object: {},
+            },
+            (description: string, value: unknown) => {
+                expect(() => {
+                    assertBoolean(value, description);
+                }).toThrowError(`${description}<boolean> is required`);
+            }
+        );
+
+        it("should return provided value if false", () => {
+            const value = assertBoolean(false, "false value");
+
+            expect(value).toBe(false);
+        });
+
+        it("should return provided value if true", () => {
+            const value = assertBoolean(true, "true value");
+
+            expect(value).toBe(true);
+        });
+    });
+
+    describe("assertNumber", () => {
+        itShouldThrowForValues(
+            {
+                string: "aaa",
+                "number as string": "12",
+                boolean: true,
+                null: null,
+                undefined: undefined, // eslint-disable-line object-shorthand
+                Object: {},
+            },
+            (description, value) => {
+                expect(() => {
+                    assertNumber(value, description);
+                }).toThrowError(`${description}<number> is required`);
+            }
+        );
+
+        it("should return provided number", () => {
+            const someNumber = 12;
+
+            const actualValue = assertNumber(12, "some number");
+
+            expect(actualValue).toBe(someNumber);
+        });
+    });
+
+    describe("assertString", () => {
+        itShouldThrowForValues(
+            {
+                number: 1,
+                boolean: true,
+                null: null,
+                undefined: undefined, // eslint-disable-line object-shorthand
+                Object: {},
+            },
+            (description, value) => {
+                expect(() => {
+                    assertString(value, description);
+                }).toThrowError(`${description}<string> is required`);
+            }
+        );
+
+        it("should return provided value if string", () => {
+            const someString = "some-string";
+
+            const actualValue = assertString(someString, "parameter name");
+
+            expect(actualValue).toBe(someString);
+        });
+    });
+
+    describe("assertRoomName", () => {
+        itShouldThrowForValues(
+            {
+                number: 1,
+                boolean: true,
+                null: null,
+                undefined: undefined, // eslint-disable-line object-shorthand
+                Object: {},
+            },
+            (description, value) => {
+                expect(() => {
+                    assertRoomName(value, description);
+                }).toThrowError(`${description}<string> is required`);
+            }
+        );
+
+        it("should throw error if roomName is not prefixed with slash", () => {
+            expect(() => assertRoomName("not-prefixed")).toThrowError("roomName must begin with a '/'");
+        });
+
+        it("should return roomName if roomName is prefixed with slash", () => {
+            const prefixedRoomName = "/some-prefix";
+
+            const actualValue = assertRoomName(prefixedRoomName);
+
+            expect(actualValue).toBe(prefixedRoomName);
+        });
+    });
+
+    describe("assertInstanceOf", () => {
+        class SomeOtherClass {
+            _param: number;
+            constructor(param: number) {
+                this._param = param;
+            }
+        }
+
+        class SomeClass {
+            _param: string;
+            constructor(param: string) {
+                this._param = param;
+            }
+        }
+
+        class SubSomeClass extends SomeClass {}
+
+        forEachObject(
+            {
+                number: 1,
+                boolean: true,
+                null: null,
+                undefined: undefined, // eslint-disable-line object-shorthand
+                Object: {},
+                someOtherClass: new SomeOtherClass(1212),
+            },
+            (value, description) => {
+                it(`should throw if ${description} is not instanceof SomeClass`, () => {
+                    expect(() => {
+                        assertInstanceOf(value, SomeClass, "someClass");
+                    }).toThrowError("someClass<SomeClass> is required");
+                });
+            }
+        );
+
+        it("should throw with provided parameterName", () => {
+            expect(() => {
+                assertInstanceOf(null, SomeClass, "someParameterName");
+            }).toThrowError("someParameterName<SomeClass> is required");
+        });
+
+        it(
+            "should throw with parameterName = type (except that first character is lower-case) if none is provided",
+            () => {
+                expect(() => {
+                    assertInstanceOf(null, SomeClass);
+                }).toThrowError("someClass<SomeClass> is required");
+            }
+        );
+
+        it("should return value if instance of class", () => {
+            const instance = new SomeClass("some value");
+
+            const actualValue = assertInstanceOf(instance, SomeClass);
+
+            expect(actualValue).toBe(instance);
+        });
+
+        it("should return value if instance of subclass", () => {
+            const instance = new SubSomeClass("some value");
+
+            const actualValue = assertInstanceOf(instance, SomeClass);
+
+            expect(actualValue).toBe(instance);
+        });
+    });
+
+    describe("assertOneOf", () => {
+        const description = "testValue";
+        const allowedValues = ["hi", "welcome"];
+
+        it("should throw if no value is provided", () => {
+            expect(() => {
+                assertOneOf(undefined, allowedValues, description);
+            }).toThrowError(`value is required`);
+        });
+
+        it("should throw if allowed values is not an array", () => {
+            expect(() => {
+                // @ts-expect-error
+                assertOneOf("hi", true, description);
+            }).toThrowError(`allowedValues<array> is required`);
+        });
+
+        it("should throw if provided value is not allowed value", () => {
+            expect(() => {
+                assertOneOf("hello", allowedValues, description);
+            }).toThrowError(
+                `${description}<string> must be one of the following: ${allowedValues.join(", ")}`
+            );
+        });
+
+        it("should return value if it is allowed", () => {
+            const value = allowedValues[0];
+
+            expect(assertOneOf(value, allowedValues, description)).toBe(value);
+        });
+    });
+
+    describe("assertRecord", () => {
+        itShouldThrowForValues(
+            {
+                string: "aaa",
+                "number as string": "12",
+                "boolean as string": "true",
+                null: null,
+                undefined: undefined, // eslint-disable-line object-shorthand
+                Array: [],
+            },
+            (description, value) => {
+                expect(() => {
+                    assertRecord(value, description);
+                }).toThrowError(`${description} must be a record`);
+            }
+        );
+
+        it("should return provided value if {}", () => {
+            const value = assertRecord({}, "emptyValue");
+
+            expect(value).toEqual({});
+        });
+
+        it("should return provided value if contains some fields", () => {
+            const o = { field: 1 };
+            const value = assertRecord(o, "emptyValue");
+
+            expect(value).toEqual(o);
+        });
+    });
+});

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,0 +1,6 @@
+export type UserConsentAction = "accepted" | "rejected" | null;
+export type ConsentGrantRequest = {
+    readonly consentRevisionId: string;
+    readonly action: UserConsentAction;
+};
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,6 +2948,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/btoa@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/btoa/-/btoa-1.2.3.tgz#2c8e7093f902bf8f0e10992a731a4996aa1a5732"
+  integrity sha512-ANNCZICS/ofxhzUl8V1DniBJs+sFQ+Yg5am1ZwVEf/sxoKY/J2+h5Fuw3xUErlZ7eJLdgzukBjZwnsV6+/2Rmg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -4231,6 +4238,15 @@ axios@0.19.0:
   dependencies:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
+
+axios@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.3.tgz#31a3d824c0ebf754a004b585e5f04a5f87e6c4ff"
+  integrity sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^28.1.1:
   version "28.1.1"
@@ -6713,7 +6729,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.14.9:
+follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -10647,6 +10663,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2955,6 +2955,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/chrome@^0.0.210":
+  version "0.0.210"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.210.tgz#6bc137e111cf42857af5012d47c036adc079616e"
+  integrity sha512-VSjQu1k6a/rAfuqR1Gi/oxHZj4+t6+LG+GobNI3ZWI6DQ+fmphNSF6TrLHG6BYK2bXc9Gb4c1uXFKRRVLaGl5Q==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
 "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -2998,6 +3006,18 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/filesystem@*":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.32.tgz#307df7cc084a2293c3c1a31151b178063e0a8edf"
+  integrity sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==
+  dependencies:
+    "@types/filewriter" "*"
+
+"@types/filewriter@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
+  integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
+
 "@types/glob@*":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.0.0.tgz#321607e9cbaec54f687a0792b2d1d370739455d2"
@@ -3020,6 +3040,11 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/har-format@*":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.10.tgz#7b4e1e0ada4d17684ac3b05d601a4871cfab11fc"
+  integrity sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg==
 
 "@types/hast@^2.0.0":
   version "2.3.4"


### PR DESCRIPTION
* add storybook's static folder to `.gitignore`
* move the necessary api functions to this lib, so we can remove the jslib-api package
* migrate jslib-api's sinon+mocha+chai tests to Jest

## Test plan

1. Install dependencies and run the tests locally: `yarn test`
2. Start the storybook and make sure the stories run as expected