### PR TITLE
Trigger deployment only when a GitHub release is created

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,8 @@
 ---
 name: Build, test & deploy
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - "package.json"
+    release:
+        types: [created]
 jobs:
     build_and_test:
         concurrency: build_and_test_main_${{ github.head_ref }}
@@ -22,10 +19,30 @@ jobs:
 
             - name: Test
               run: yarn test
+    get_version_tag:
+        runs-on: ubuntu-latest
+        needs: build_and_test
+        outputs:
+            tag: ${{ steps.tag_check.outputs.tag }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Get version tag
+              id: tag_check
+              # 1st sed: remove major.minor.patch numbers
+              # 2nd sed: remove wrapper quotes
+              # 3rd sed: remove "-" and tag version if exists
+              run: |
+                  TAG=$(npm pkg get version \
+                  | sed 's/\([0-9]*\.[0-9]*\.[0-9]*\)//' \
+                  | sed 's/^"\(.*\)"$/\1/' \
+                  | sed 's/-\([a-z]*\)\([0-9]*\)/\1/')
+                  echo "tag=$TAG" >> $GITHUB_OUTPUT
     deploy_cdn:
         concurrency: deploy_cdn_main_${{ github.head_ref }}
         name: Deploy to CDN
-        needs: build_and_test
+        needs: get_version_tag
+        # Only run when there's no version tag (e.g. -beta) specified
+        if: ${{ needs.get_version_tag.outputs.tag == 0 }}
         runs-on: ubuntu-latest
         env:
             GITHUB_TOKEN: ${{ secrets.WHEREBY_GITHUB_TOKEN }}
@@ -59,18 +76,27 @@ jobs:
     deploy_npm:
         concurrency: deploy_npm_main_${{ github.head_ref }}
         name: Deploy to npm
-        needs: build_and_test
+        needs: get_version_tag
         runs-on: ubuntu-latest
-        env:
-            GITHUB_TOKEN: ${{ secrets.WHEREBY_GITHUB_TOKEN }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
-            - name: Build
-              uses: ./.github/actions/build
-
-            - name: Deploy to npm
-              uses: JS-DevTools/npm-publish@v1
+            # Setup .npmrc file to publish to npm
+            - uses: actions/setup-node@v3
               with:
-                  token: ${{ secrets.NPM_TOKEN }}
+                  node-version: "16.x"
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Publish on npm
+              run: |
+                  TAG=${{ needs.get_version_tag.outputs.tag }}
+                  if [[ -z ${TAG} ]]; then
+                      echo "deploy with latest tag"
+                      npm publish
+                  else
+                      echo "deploy with ${{ needs.get_version_tag.outputs.tag }} tag"
+                      npm publish --tag ${{ needs.get_version_tag.outputs.tag }}
+                  fi
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
* Replace the trigger in the deploy workflow to deploy a new version when a GitHub release is created.
* Parse the version tag (e.g. alpha, beta) from the package.json and use it in the npm publish script when exists. Otherwise deploy the package with the default ("latest") tag.
* Replace the 3rd party JS-DevTools/npm-publish action with pure bash and npm scripts.
* Skip CDN deployment when the release has a version tag.