### PR TITLE
Add display name support

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -13,43 +13,4 @@ module.exports = {
 
         return config;
     },
-    previewHead: (head) => `
-        ${head}
-        <style>
-        .bouncingball {
-            width:140px;
-            height:140px;
-            border-radius:100%;
-            background:#CCC;
-            animation: bounce 1s;
-            transform: translateY(0px);
-            animation-iteration-count: infinite;
-            position:absolute;
-            margin:50px;
-            overflow: hidden;
-          }
-          
-          @keyframes bounce {
-              0% {top: 0;
-                  -webkit-animation-timing-function: ease-in;
-              }
-              40% {}
-              50% {top: 140px;
-                  height: 140px;
-                  -webkit-animation-timing-function: ease-out;
-              }
-              55% {top: 160px; height: 120px; 
-                  -webkit-animation-timing-function: ease-in;}
-              65% {top: 120px; height: 140px; 
-                  -webkit-animation-timing-function: ease-out;}
-              95% {
-                  top: 0;		
-                  -webkit-animation-timing-function: ease-in;
-              }
-              100% {top: 0;
-                  -webkit-animation-timing-function: ease-in;
-              }
-          }
-        </style>
-    `,
 };

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -492,4 +492,13 @@ export default class RoomConnection extends TypedEventTarget {
         localAudioTrack.enabled = newValue;
         this.signalSocket.emit("enable_audio", { enabled: newValue });
     }
+
+    setDisplayName(displayName: string): void {
+        this.signalSocket.emit("send_client_metadata", {
+            type: "UserData",
+            payload: {
+                displayName,
+            },
+        });
+    }
 }

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -132,8 +132,9 @@ export default class RoomConnection extends TypedEventTarget {
     private roomConnectionState: "" | "connecting" | "connected" | "disconnected" = "";
     private logger: Logger;
     private localStream?: MediaStream;
+    private displayName?: string;
 
-    constructor(roomUrl: string, { localMediaConstraints, localStream, logger }: RoomConnectionOptions) {
+    constructor(roomUrl: string, { displayName, localMediaConstraints, localStream, logger }: RoomConnectionOptions) {
         super();
         this.roomUrl = new URL(roomUrl); // Throw if invalid Whereby room url
         this.logger = logger || {
@@ -142,6 +143,7 @@ export default class RoomConnection extends TypedEventTarget {
             log: noop,
             warn: noop,
         };
+        this.displayName = displayName;
         this.localStream = localStream;
         this.localMediaConstraints = localMediaConstraints;
 
@@ -407,7 +409,7 @@ export default class RoomConnection extends TypedEventTarget {
                     isVideoEnabled: !!this.localStream?.getVideoTracks().find((t) => t.enabled),
                 },
                 deviceCapabilities: { canScreenshare: true },
-                displayName: "SDK",
+                displayName: this.displayName,
                 isCoLocated: false,
                 isDevicePermissionDenied: false,
                 kickFromOtherRooms: false,

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -59,6 +59,11 @@ export default function useRoomConnection(
             dispatch({ type: "PARTICIPANT_VIDEO_ENABLED", payload: { participantId, isVideoEnabled } });
         });
 
+        roomConnection.addEventListener("participant_metadata_changed", (e) => {
+            const { participantId, displayName } = e.detail;
+            dispatch({ type: "PARTICIPANT_METADATA_CHANGED", payload: { participantId, displayName } });
+        });
+
         roomConnection.join();
 
         return () => {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -6,6 +6,7 @@ import VideoElement from "./VideoElement";
 interface RoomConnectionActions {
     toggleCamera(enabled?: boolean): void;
     toggleMicrophone(enabled?: boolean): void;
+    setDisplayName(displayName: string): void;
 }
 
 interface RoomConnectionComponents {
@@ -73,6 +74,10 @@ export default function useRoomConnection(
             },
             toggleMicrophone: (enabled) => {
                 roomConnection?.toggleMicrophone(enabled);
+            },
+            setDisplayName: (displayName) => {
+                roomConnection?.setDisplayName(displayName);
+                dispatch({ type: "LOCAL_CLIENT_DISPLAY_NAME_CHANGED", payload: { displayName } });
             },
         },
         {

--- a/src/lib/reducer.ts
+++ b/src/lib/reducer.ts
@@ -50,6 +50,13 @@ type Action =
           };
       }
     | {
+          type: "PARTICIPANT_METADATA_CHANGED";
+          payload: {
+              participantId: string;
+              displayName: string;
+          };
+      }
+    | {
           type: "LOCAL_CLIENT_DISPLAY_NAME_CHANGED";
           payload: {
               displayName: string;
@@ -113,6 +120,15 @@ export default function reducer(state: RoomState, action: Action): RoomState {
                 remoteParticipants: updateParticipant(state.remoteParticipants, action.payload.participantId, {
                     isVideoEnabled: action.payload.isVideoEnabled,
                 }),
+            };
+        case "PARTICIPANT_METADATA_CHANGED":
+            return {
+                ...state,
+                remoteParticipants: [
+                    ...state.remoteParticipants.map((p) =>
+                        p.id === action.payload.participantId ? { ...p, displayName: action.payload.displayName } : p
+                    ),
+                ],
             };
         case "LOCAL_CLIENT_DISPLAY_NAME_CHANGED":
             if (!state.localParticipant) return state;

--- a/src/lib/reducer.ts
+++ b/src/lib/reducer.ts
@@ -48,6 +48,12 @@ type Action =
               participantId: string;
               isVideoEnabled: boolean;
           };
+      }
+    | {
+          type: "LOCAL_CLIENT_DISPLAY_NAME_CHANGED";
+          payload: {
+              displayName: string;
+          };
       };
 
 function updateParticipant(
@@ -107,6 +113,12 @@ export default function reducer(state: RoomState, action: Action): RoomState {
                 remoteParticipants: updateParticipant(state.remoteParticipants, action.payload.participantId, {
                     isVideoEnabled: action.payload.isVideoEnabled,
                 }),
+            };
+        case "LOCAL_CLIENT_DISPLAY_NAME_CHANGED":
+            if (!state.localParticipant) return state;
+            return {
+                ...state,
+                localParticipant: { ...state.localParticipant, displayName: action.payload.displayName },
             };
         default:
             throw state;

--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -9,6 +9,30 @@ export default {
     },
 };
 
+const DisplayNameForm = ({
+    initialDisplayName,
+    onSetDisplayName,
+}: {
+    initialDisplayName?: string;
+    onSetDisplayName: (displayName: string) => void;
+}) => {
+    const [displayName, setDisplayName] = useState(initialDisplayName || "");
+
+    return (
+        <div>
+            <label htmlFor="displayName">Display name: </label>
+            <input
+                type="text"
+                name="displayName"
+                id="displayName"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+            />
+            <button onClick={() => onSetDisplayName(displayName || "")}>Save</button>
+        </div>
+    );
+};
+
 const VideoExperience = ({
     displayName,
     roomName,
@@ -29,7 +53,7 @@ const VideoExperience = ({
     });
 
     const { localParticipant, remoteParticipants } = state;
-    const { toggleCamera, toggleMicrophone } = actions;
+    const { setDisplayName, toggleCamera, toggleMicrophone } = actions;
     const { VideoView } = components;
 
     return (
@@ -62,7 +86,7 @@ const VideoExperience = ({
                                         />
                                     )}
                                 </div>
-                                <div className="displayName">{participant.displayName}</div>
+                                <div className="displayName">{participant.displayName || "Guest"}</div>
                             </>
                         ) : null}
                     </div>
@@ -71,6 +95,7 @@ const VideoExperience = ({
             <div className="controls">
                 <button onClick={() => toggleCamera()}>Toggle camera</button>
                 <button onClick={() => toggleMicrophone()}>Toggle microphone</button>
+                <DisplayNameForm initialDisplayName={displayName} onSetDisplayName={setDisplayName} />
             </div>
         </div>
     );

--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -1,12 +1,25 @@
 import React, { useState } from "react";
 import { useLocalMedia, useRoomConnection, VideoElement } from "../lib/react";
+import "./styles.css";
 
 export default {
     title: "Examples/Custom UI",
+    argTypes: {
+        displayName: { control: "text" },
+    },
 };
 
-const VideoExperience = ({ roomName, localStream }: { roomName: string; localStream?: MediaStream }) => {
+const VideoExperience = ({
+    displayName,
+    roomName,
+    localStream,
+}: {
+    displayName?: string;
+    roomName: string;
+    localStream?: MediaStream;
+}) => {
     const [state, actions, components] = useRoomConnection(roomName, {
+        displayName,
         localMediaConstraints: {
             audio: true,
             video: true,
@@ -20,52 +33,57 @@ const VideoExperience = ({ roomName, localStream }: { roomName: string; localStr
     const { VideoView } = components;
 
     return (
-        <div style={{ minHeight: 400, backgroundColor: "pink" }}>
-            {[localParticipant, ...remoteParticipants].map((participant, i) => (
-                <div key={participant?.id || i}>
-                    {participant ? (
-                        <div
-                            className="bouncingball"
-                            style={{
-                                animationDelay: `${Math.random() * 1000}ms`,
-                                left: i * 145,
-                                ...(participant.isAudioEnabled
-                                    ? {
-                                          border: "2px solid grey",
-                                      }
-                                    : null),
-                                ...(!participant.isVideoEnabled
-                                    ? {
-                                          backgroundColor: "green",
-                                      }
-                                    : null),
-                            }}
-                        >
-                            {participant.stream && participant.isVideoEnabled && (
-                                <VideoView
-                                    stream={participant.stream}
-                                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
-                                />
-                            )}
-                        </div>
-                    ) : null}
-                </div>
-            ))}
-
-            <button onClick={() => toggleCamera()}>Toggle camera</button>
-            <button onClick={() => toggleMicrophone()}>Toggle microphone</button>
+        <div>
+            <div className="container">
+                {[localParticipant, ...remoteParticipants].map((participant, i) => (
+                    <div className="participantWrapper" key={participant?.id || i}>
+                        {participant ? (
+                            <>
+                                <div
+                                    className="bouncingball"
+                                    style={{
+                                        animationDelay: `${Math.random() * 1000}ms`,
+                                        ...(participant.isAudioEnabled
+                                            ? {
+                                                  border: "2px solid grey",
+                                              }
+                                            : null),
+                                        ...(!participant.isVideoEnabled
+                                            ? {
+                                                  backgroundColor: "green",
+                                              }
+                                            : null),
+                                    }}
+                                >
+                                    {participant.stream && participant.isVideoEnabled && (
+                                        <VideoView
+                                            stream={participant.stream}
+                                            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                                        />
+                                    )}
+                                </div>
+                                <div className="displayName">{participant.displayName}</div>
+                            </>
+                        ) : null}
+                    </div>
+                ))}
+            </div>
+            <div className="controls">
+                <button onClick={() => toggleCamera()}>Toggle camera</button>
+                <button onClick={() => toggleMicrophone()}>Toggle microphone</button>
+            </div>
         </div>
     );
 };
 
-export const Simplistic = () => {
+export const Simplistic = ({ displayName }: { displayName?: string }) => {
     const [isConnected, setIsConnected] = useState(false);
     const [roomName, setRoomName] = useState(process.env.STORYBOOK_ROOM);
 
     return (
         <div>
             {roomName && isConnected ? (
-                <VideoExperience roomName={roomName} />
+                <VideoExperience displayName={displayName} roomName={roomName} />
             ) : (
                 <div>
                     <label>Room name</label>
@@ -75,6 +93,10 @@ export const Simplistic = () => {
             )}
         </div>
     );
+};
+
+Simplistic.args = {
+    displayName: undefined,
 };
 
 export const WithPreCall = () => {

--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -5,7 +5,8 @@ import "./styles.css";
 export default {
     title: "Examples/Custom UI",
     argTypes: {
-        displayName: { control: "text" },
+        displayName: { control: "text", defaultValue: "SDK" },
+        roomUrl: { control: "text", defaultValue: process.env.STORYBOOK_ROOM, type: { required: true } },
     },
 };
 
@@ -101,38 +102,28 @@ const VideoExperience = ({
     );
 };
 
-export const Simplistic = ({ displayName }: { displayName?: string }) => {
-    const [isConnected, setIsConnected] = useState(false);
-    const [roomName, setRoomName] = useState(process.env.STORYBOOK_ROOM);
+const roomRegEx = new RegExp(/^https:\/\/.*\/.*/);
 
-    return (
-        <div>
-            {roomName && isConnected ? (
-                <VideoExperience displayName={displayName} roomName={roomName} />
-            ) : (
-                <div>
-                    <label>Room name</label>
-                    <input type="text" value={roomName} onChange={(e) => setRoomName(e.target.value)} />
-                    <button onClick={() => setIsConnected(true)}>Connect</button>
-                </div>
-            )}
-        </div>
-    );
+export const Simplistic = ({ roomUrl, displayName }: { roomUrl: string; displayName?: string }) => {
+    if (!roomUrl || !roomUrl.match(roomRegEx)) {
+        return <p>Set room url on the Controls panel</p>;
+    }
+
+    return <VideoExperience displayName={displayName} roomName={roomUrl} />;
 };
 
-Simplistic.args = {
-    displayName: undefined,
-};
-
-export const WithPreCall = () => {
+export const WithPreCall = ({ roomUrl, displayName }: { roomUrl: string; displayName?: string }) => {
     const [localStream] = useLocalMedia();
     const [shouldJoin, setShouldJoin] = useState(false);
-    const roomUrl = process.env.STORYBOOK_ROOM || "";
+
+    if (!roomUrl || !roomUrl.match(roomRegEx)) {
+        return <p>Set room url on the Controls panel</p>;
+    }
 
     return (
         <div>
             {shouldJoin ? (
-                <VideoExperience roomName={roomUrl} localStream={localStream} />
+                <VideoExperience displayName={displayName} roomName={roomUrl} localStream={localStream} />
             ) : (
                 <div>{localStream && <VideoElement stream={localStream} />}</div>
             )}

--- a/src/stories/styles.css
+++ b/src/stories/styles.css
@@ -1,33 +1,68 @@
+.container {
+    display: flex;
+    min-height: 290px;
+    background-color: pink;
+    gap: 10px;
+    padding: 10px;
+}
+
+.participantWrapper {
+    position: relative;
+    flex-direction: column;
+    display: flex;
+    width: 140px;
+}
+
 .bouncingball {
-    width:140px;
-    height:140px;
-    border-radius:100%;
-    background:#CCC;
+    width: 140px;
+    height: 140px;
+    border-radius: 100%;
+    background: #ccc;
     animation: bounce 1s;
     transform: translateY(0px);
     animation-iteration-count: infinite;
-    position:absolute;
-    margin:50px;
-  }
-  
-  @keyframes bounce {
-      0% {top: 0;
-          -webkit-animation-timing-function: ease-in;
-      }
-      40% {}
-      50% {top: 140px;
-          height: 140px;
-          -webkit-animation-timing-function: ease-out;
-      }
-      55% {top: 160px; height: 120px; 
-          -webkit-animation-timing-function: ease-in;}
-      65% {top: 120px; height: 140px; 
-          -webkit-animation-timing-function: ease-out;}
-      95% {
-          top: 0;		
-          -webkit-animation-timing-function: ease-in;
-      }
-      100% {top: 0;
-          -webkit-animation-timing-function: ease-in;
-      }
-  }
+    position: absolute;
+    top: 25px;
+    overflow: hidden;
+}
+
+.displayName {
+    text-align: center;
+    color: #ffffff;
+    padding: 2px 4px;
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+@keyframes bounce {
+    0% {
+        top: 25px;
+        -webkit-animation-timing-function: ease-in;
+    }
+    40% {
+    }
+    50% {
+        top: 140px;
+        height: 140px;
+        -webkit-animation-timing-function: ease-out;
+    }
+    55% {
+        top: 160px;
+        height: 120px;
+        -webkit-animation-timing-function: ease-in;
+    }
+    65% {
+        top: 120px;
+        height: 140px;
+        -webkit-animation-timing-function: ease-out;
+    }
+    95% {
+        top: 25px;
+        -webkit-animation-timing-function: ease-in;
+    }
+    100% {
+        top: 25px;
+        -webkit-animation-timing-function: ease-in;
+    }
+}
+

--- a/src/stories/styles.css
+++ b/src/stories/styles.css
@@ -34,6 +34,12 @@
     background-color: rgba(0, 0, 0, 0.5);
 }
 
+.controls {
+    display: flex;
+    gap: 10px;
+    margin-top: 12px;
+}
+
 @keyframes bounce {
     0% {
         top: 25px;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -162,6 +162,7 @@ declare module "@whereby/jslib-commons/src/utils/ServerSocket" {
         identify_device: IdentifyDeviceRequest;
         join_room: JoinRoomRequest;
         leave_room: void;
+        send_client_metadata: { type: string; payload: { displayName?: string } };
     }
 
     export default class ServerSocket {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -134,9 +134,15 @@ declare module "@whereby/jslib-commons/src/utils/ServerSocket" {
         isVideoEnabled: boolean;
     }
 
+    interface ClientMetadataReceivedEvent {
+        type: string;
+        payload: { clientId: string; displayName: string };
+    }
+
     interface SignalEvents {
         audio_enabled: AudioEnabledEvent;
         client_left: ClientLeftEvent;
+        client_metadata_received: ClientMetadataReceivedEvent;
         connect: void;
         device_identified: void;
         new_client: NewClientEvent;


### PR DESCRIPTION
Add display name support:

* Initial display name support: set display name before joining a room
* Change display name when client is already in the room
* Watch other clients' display name changes and show the updates immediately

StoryBook story changes:

* Use styles from the styles.css file instead of inline styles properties.
* Move room url field to a StoryBook arg: this allows us to set the room url once and keep it when StoryBook
reloads due some code change.

### Testing

1. Start StoryBook with or without a `STORYBOOK_ROOM` env var
    * when env var is present: its value is inserted to the `roomUrl` Story arg.
    * when env var is missing: you must paste a room url manually on the control panel
3. Join a room with the sdk and with another client via the regular room / embed view => Client names should be visible in the browser sdk stories
4. Change display name in the story => the other client should see the change without reloading the browser
5. Change the display name for the client in the regular / embed view => The browser sdk story should show the change

### Gotcha

The control panel's `displayName` prop only has effect before joining the room. To change the name during a meeting, you must use the other "Display name" field inside the Story.

### Screenshot

![Screenshot 2023-01-31 at 16 33 12](https://user-images.githubusercontent.com/1159931/215804530-210e4668-c05b-440a-8cc2-f35098b4c764.png)
