### PR TITLE
Do not show non-person clients

### DIFF
--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -20,6 +20,7 @@ import ServerSocket, {
     ClientLeftEvent,
     NewClientEvent,
     RoomJoinedEvent as SignalRoomJoinedEvent,
+    SignalClient,
 } from "@whereby/jslib-commons/src/utils/ServerSocket";
 
 type Logger = Pick<Console, "debug" | "error" | "log" | "warn">;
@@ -71,6 +72,8 @@ interface RoomEventsMap {
 
 const API_BASE_URL = "https://ip-127-0-0-1.hereby.dev:4090";
 const SIGNAL_BASE_URL = "wss://ip-127-0-0-1.hereby.dev:4070";
+
+const NON_PERSON_ROLES = ["recorder", "streamer"];
 
 function createSocket() {
     const parsedUrl = new URL(SIGNAL_BASE_URL);
@@ -173,6 +176,9 @@ export default class RoomConnection extends TypedEventTarget {
     }
 
     private _handleNewClient({ client }: NewClientEvent) {
+        if (NON_PERSON_ROLES.includes(client.role.roleName)) {
+            return;
+        }
         const remoteParticipant = new RemoteParticipant({ ...client, newJoiner: true });
         this.remoteParticipants = [...this.remoteParticipants, remoteParticipant];
         this._handleAcceptStreams([remoteParticipant]);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -97,12 +97,17 @@ declare module "@whereby/jslib-commons/src/utils/ServerSocket" {
         timeout?: number;
     }
 
+    interface ClientRole {
+        roleName: string;
+    }
+
     interface SignalClient {
         displayName: string;
         id: string;
         streams: string[];
         isAudioEnabled: boolean;
         isVideoEnabled: boolean;
+        role: ClientRole;
     }
 
     interface AudioEnabledEvent {


### PR DESCRIPTION
`recorder` and `streamer` clients should not be added to the remoteParticipant list

### Test plan

1. Open a room url with browser sdk, where the room has streaming and cloud recording set up
2. Start recording and streaming => the browser-sdk's StoryBook story should not show the `recorder` and `streamer` clients in the bouncing ball area.