### PR TITLE
Use proper Whereby domain for api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha",
   "description": "Modules for integration Whereby video in web apps",
   "author": "Whereby AS",
   "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -77,8 +77,8 @@ interface RoomEventsMap {
     room_joined: CustomEvent<RoomJoinedEvent>;
 }
 
-const API_BASE_URL = "https://ip-127-0-0-1.hereby.dev:4090";
-const SIGNAL_BASE_URL = "wss://ip-127-0-0-1.hereby.dev:4070";
+const API_BASE_URL = "https://api.appearin.net";
+const SIGNAL_BASE_URL = "wss://signal.appearin.net";
 
 const NON_PERSON_ROLES = ["recorder", "streamer"];
 


### PR DESCRIPTION
* Replace the test environment api endpoints with the production ones
* Use `alpha` tag for the upcoming package version