### PR TITLE
Roll up TS definitions into 1 types.d.ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "dist/lib.cjs.js",
   "module": "dist/lib.esm.js",
   "type": "module",
+  "types": "dist/types.d.ts",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "rollup -c",
@@ -55,6 +56,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.75.6",
+    "rollup-plugin-dts": "^5.1.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-jest": "^29.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import replace from "@rollup/plugin-replace";
 import { terser } from "rollup-plugin-terser";
 import pkg from "./package.json";
 import typescript from "rollup-plugin-typescript2";
+import dts from "rollup-plugin-dts";
 
 const replaceValues = {
     preventAssignment: true,
@@ -59,5 +60,11 @@ export default [
             format: "esm",
         },
         plugins: [nodeResolve(), commonjs(), json(), terser(), replace(replaceValues), typescript()],
+    },
+    // Roll-up .d.ts definition files
+    {
+        input: "./dist/lib/index.d.ts",
+        output: [{ file: "dist/types.d.ts", format: "es" }],
+        plugins: [dts()],
     },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
       "resolveJsonModule": true,
       "isolatedModules": true,
       "noEmit": true,
+      "declaration": true,
       "jsx": "react",
       "baseUrl": "./",
       "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10756,6 +10756,15 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rollup-plugin-dts@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-5.1.1.tgz#8cc36ab13135b77ef0cfd6107e4af561c5dffd04"
+  integrity sha512-zpgo52XmnLg8w4k3MScinFHZK1+ro6r7uVe34fJ0Ee8AM45FvgvTuvfWWaRgIpA4pQ1BHJuu2ospncZhkcJVeA==
+  dependencies:
+    magic-string "^0.27.0"
+  optionalDependencies:
+    "@babel/code-frame" "^7.18.6"
+
 rollup-plugin-terser@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"


### PR DESCRIPTION
The type definitions were missing from the `/dist` folder. This PR extends the TS + rollup configs to create declaration files and then bundle them into 1 `types.d.ts` file.

### Test plan

1. Run `yarn build` => confirm that `dist` folder has a `types.d.ts`
2. Add browser-sdk to a TypeScript project => see the types in actions and enjoy the enhanced developer experience