### PR TITLE
Provide named exports for lib entrypoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 export default {
     preset: "ts-jest",
     testEnvironment: "jest-environment-node",
+    testMatch: ["<rootDir>/src/**/__tests__/**/*.[jt]s?(x)", "<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)"],
     transform: {},
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ export default [
     {
         input: "src/lib/index.ts",
         output: {
-            exports: "default",
+            exports: "named",
             file: "dist/lib.cjs.js",
             format: "cjs",
         },
@@ -44,7 +44,7 @@ export default [
     {
         input: "src/lib/index.ts",
         output: {
-            exports: "default",
+            exports: "named",
             file: "dist/lib.esm.js",
             format: "esm",
         },
@@ -55,7 +55,7 @@ export default [
     {
         input: "src/lib/index.ts",
         output: {
-            exports: "default",
+            exports: "named",
             file: `dist/${makeCdnFilename()}`,
             format: "esm",
         },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,3 @@
-import { useRoomConnection } from "./react";
 import "./embed";
-
-export default { sdkVersion: "__SDK_VERSION__", useRoomConnection };
+export { useRoomConnection } from "./react";
+export const sdkVersion = "__SDK_VERSION__";

--- a/src/stories/prebuilt-ui.stories.tsx
+++ b/src/stories/prebuilt-ui.stories.tsx
@@ -1,6 +1,6 @@
 import { Story } from "@storybook/react";
 import React from "react";
-import "../lib";
+import "../lib/embed";
 
 interface WherebyEmbedAttributes {
     audio: boolean;


### PR DESCRIPTION
This change moves away from a default export in the lib entrypoint to named exports. This change will make it less verbose to import specific modules, and also allow for tree-shaking.

An additional change is to just look for tests in the src folder.