### PR TITLE
Fix broken npm publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,9 @@ jobs:
                   node-version: "16.x"
                   registry-url: "https://registry.npmjs.org"
 
+            - name: Build
+              uses: ./.github/actions/build
+
             - name: Publish on npm
               run: |
                   TAG=${{ needs.get_version_tag.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0-alpha1",
   "description": "Modules for integration Whereby video in web apps",
   "author": "Whereby AS",
   "license": "MIT",


### PR DESCRIPTION
This fixes the missing dist-folder when publishing to npm, caused by a missing build step in the npm deploy job in the deployment pipeline.