### PR TITLE
Fix npm deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,9 @@ jobs:
                   node-version: "16.x"
                   registry-url: "https://registry.npmjs.org"
 
+            - name: Build
+              uses: ./.github/actions/build
+
             - name: Publish on npm
               run: |
                   TAG=${{ needs.get_version_tag.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "dist/lib.cjs.js",
   "module": "dist/lib.esm.js",
   "type": "module",
+  "files": ["dist/**/*.js", "dist/*.d.ts"],
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",


### PR DESCRIPTION
This fixes the missing dist-folder when publishing to npm, caused by a missing build step in the npm deploy job in the deployment pipeline.