### PR TITLE
Handle video muted attribute programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "2.0.0-alpha3",
+  "version": "2.0.0-alpha4",
   "description": "Modules for integration Whereby video in web apps",
   "author": "Whereby AS",
   "license": "MIT",

--- a/src/lib/react/VideoView.tsx
+++ b/src/lib/react/VideoView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useEffect, useRef } from "react";
 
 interface VideoViewSelfProps {
     stream: MediaStream;
@@ -8,12 +8,24 @@ interface VideoViewSelfProps {
 type VideoViewProps = VideoViewSelfProps &
     React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
 
-export default ({ stream, ...rest }: VideoViewProps) => {
-    const videoEl = useCallback<(node: HTMLVideoElement) => void>((node) => {
-        if (node !== null && node.srcObject !== stream) {
-            node.srcObject = stream;
+export default ({ muted, stream, ...rest }: VideoViewProps) => {
+    const videoEl = useRef<HTMLVideoElement>(null);
+
+    useEffect(() => {
+        if (!videoEl.current) {
+            return;
         }
-    }, []);
+
+        if (videoEl.current.srcObject !== stream) {
+            videoEl.current.srcObject = stream;
+        }
+
+        // Handle muting programatically, not as video attribute
+        // https://stackoverflow.com/questions/14111917/html5-video-muted-but-still-playing
+        if (videoEl.current.muted !== muted) {
+            videoEl.current.muted = Boolean(muted);
+        }
+    }, [muted, stream, videoEl]);
 
     return <video ref={videoEl} autoPlay playsInline {...rest} />;
 };


### PR DESCRIPTION
It seems passing muted attribute to video element has some gotchas depending on autoplay policy and readystate of the stream. This change here makes us handle the muted attribute manually, like setting the srcObject stream.