### PR TITLE
Add support for passing room key to locked rooms

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,8 @@ export default {
     preset: "ts-jest",
     testEnvironment: "jsdom",
     testMatch: ["<rootDir>/src/**/__tests__/**/*.[jt]s?(x)", "<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)"],
-    transform: {},
+    transform: {
+        "^.+\\.(j|t)sx?$": "ts-jest",
+    },
+    transformIgnorePatterns: ["node_modules/(?!(@whereby/jslib-media)/)"],
 };

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -142,10 +142,16 @@ export default class RoomConnection extends TypedEventTarget {
     private logger: Logger;
     private _ownsLocalMedia = false;
     private displayName?: string;
+    private _roomKey: string | null;
 
-    constructor(roomUrl: string, { displayName, localMediaConstraints, logger, localMedia }: RoomConnectionOptions) {
+    constructor(
+        roomUrl: string,
+        { displayName, localMedia, localMediaConstraints, logger, roomKey }: RoomConnectionOptions
+    ) {
         super();
         this.roomUrl = new URL(roomUrl); // Throw if invalid Whereby room url
+        const searchParams = new URLSearchParams(this.roomUrl.search);
+        this._roomKey = roomKey || searchParams.get("roomKey");
         this.logger = logger || {
             debug: noop,
             error: noop,
@@ -202,6 +208,10 @@ export default class RoomConnection extends TypedEventTarget {
             const { enabled } = e.detail;
             this.signalSocket.emit("enable_audio", { enabled });
         });
+    }
+
+    public get roomKey(): string | null {
+        return this._roomKey;
     }
 
     private _handleNewClient({ client }: NewClientEvent) {
@@ -433,7 +443,7 @@ export default class RoomConnection extends TypedEventTarget {
                 isDevicePermissionDenied: false,
                 kickFromOtherRooms: false,
                 organizationId: organization.organizationId,
-                roomKey: null,
+                roomKey: this.roomKey,
                 roomName: this.roomUrl.pathname,
                 selfId: "",
                 userAgent: `browser-sdk:${sdkVersion || "unknown"}`,

--- a/src/lib/__tests__/RoomConnection.spec.ts
+++ b/src/lib/__tests__/RoomConnection.spec.ts
@@ -1,0 +1,30 @@
+import { jest } from "@jest/globals";
+
+import RoomConnection from "../RoomConnection";
+
+jest.mock("../LocalMedia");
+
+describe("RoomConnection", () => {
+    describe("constructor", () => {
+        it("should set room key when part of url", () => {
+            const roomKey = "abc";
+
+            const roomConnection = new RoomConnection(`https://subdomain.whereby.com/<some-room>?roomKey=${roomKey}`, {
+                localMediaConstraints: { audio: true, video: true },
+            });
+
+            expect(roomConnection.roomKey).toEqual(roomKey);
+        });
+
+        it("should prefer room key passed directly in options", () => {
+            const roomKey = "abc";
+
+            const roomConnection = new RoomConnection(`https://subdomain.whereby.com/<some-room>?roomKey=urlKey`, {
+                localMediaConstraints: { audio: true, video: true },
+                roomKey,
+            });
+
+            expect(roomConnection.roomKey).toEqual(roomKey);
+        });
+    });
+});


### PR DESCRIPTION
In order to support connecting to locked rooms, we need the ability to pass a valid room key. This can now be done in two ways; either have the room key as part of the room url, or have the room key passed explicityly in the RoomConnection options.