### PR TITLE
Fix signal socket connection issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "2.0.0-alpha7",
+  "version": "2.0.0-alpha8",
   "description": "Modules for integration Whereby video in web apps",
   "author": "Whereby AS",
   "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -94,6 +94,7 @@ function createSocket() {
         reconnectionDelay: 5000,
         reconnectionDelayMax: 30000,
         timeout: 10000,
+        withCredentials: true,
     };
 
     return new ServerSocket(SOCKET_HOST, socketConf);
@@ -424,15 +425,11 @@ export default class RoomConnection extends TypedEventTarget {
         // Identify device on signal connection
         const deviceCredentials = await this.credentialsService.getCredentials();
 
-        this.signalSocket.connect();
-
-        // TODO: Handle connection and failed connection properly
-        this.signalSocket.on("connect", () => {
-            this.logger.log("Connected to signal socket");
-            this.signalSocket.emit("identify_device", { deviceCredentials });
-        });
+        this.logger.log("Connecting to signal socket");
+        this.signalSocket.emit("identify_device", { deviceCredentials });
 
         this.signalSocket.once("device_identified", () => {
+            this.logger.log("Connected to signal socket");
             this.signalSocket.emit("join_room", {
                 avatarUrl: null,
                 config: {


### PR DESCRIPTION
Seems like the signal socket connect mechanism has been partially broken, leading to failed connection attempts. This change makes this logic more resillient by emitting the identify_device message straight away, not waiting for the connect event.

**Tested like:**
1. STORYBOOK_ROOM=<link_to_unlocked_room> yarn storybook
2. Go to http://localhost:6006/?path=/story/examples-custom-ui--room-connection-with-local-media
3. Click connect, verify you are able to connect