### PR TITLE
Add support for sending and receiving chat messages

### DIFF
--- a/src/stories/components/VideoExperience.tsx
+++ b/src/stories/components/VideoExperience.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import DisplayNameForm from "./DisplayNameForm";
 import { LocalMediaRef } from "../../lib/react/useLocalMedia";
 import useRoomConnection from "../../lib/react/useRoomConnection";
@@ -12,6 +12,7 @@ export default function VideoExperience({
     roomName: string;
     localMedia?: LocalMediaRef;
 }) {
+    const [chatMessage, setChatMessage] = useState("");
     const { state, actions, components } = useRoomConnection(roomName, {
         displayName,
         localMediaConstraints: {
@@ -22,12 +23,25 @@ export default function VideoExperience({
         logger: console,
     });
 
-    const { localParticipant, remoteParticipants } = state;
-    const { setDisplayName, toggleCamera, toggleMicrophone } = actions;
+    const { localParticipant, mostRecentChatMessage, remoteParticipants } = state;
+    const { sendChatMessage, setDisplayName, toggleCamera, toggleMicrophone } = actions;
     const { VideoView } = components;
 
     return (
         <div>
+            <div className="chat">
+                <div className="last_message">{mostRecentChatMessage?.text}</div>
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        sendChatMessage(chatMessage);
+                        setChatMessage("");
+                    }}
+                >
+                    <input type="text" value={chatMessage} onChange={(e) => setChatMessage(e.target.value)} />
+                    <button type="submit">Send message</button>
+                </form>
+            </div>
             <div className="container">
                 {[localParticipant, ...remoteParticipants].map((participant, i) => (
                     <div className="participantWrapper" key={participant?.id || i}>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -109,6 +109,17 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         isAudioEnabled: boolean;
     }
 
+    interface ChatMessage {
+        id: string;
+        messageType: "text";
+        roomName: string;
+        senderId: string;
+        sig: string;
+        text: string;
+        timestamp: string;
+        userId: string;
+    }
+
     interface ClientLeftEvent {
         clientId: string;
     }
@@ -137,6 +148,7 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         audio_enabled: AudioEnabledEvent;
         client_left: ClientLeftEvent;
         client_metadata_received: ClientMetadataReceivedEvent;
+        chat_message: ChatMessage;
         connect: void;
         device_identified: void;
         new_client: NewClientEvent;
@@ -157,6 +169,7 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
     }
 
     interface SignalRequests {
+        chat_message: { text: string };
         enable_audio: { enabled: boolean };
         enable_video: { enabled: boolean };
         identify_device: IdentifyDeviceRequest;


### PR DESCRIPTION
This change implements a `chatMessages` property on the room state, which is updated whenever a new chat message has been sent in the room. Also, a new action `sendChatMessage(text)` is exposed to allow sending messages.