### PR TITLE
Use proper file extension for cjs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "2.0.0-alpha9",
+  "version": "2.0.0-alpha10",
   "description": "Modules for integration Whereby video in web apps",
   "author": "Whereby AS",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "source": "src/index.js",
-  "main": "dist/lib.cjs.js",
+  "main": "dist/lib.cjs",
   "module": "dist/lib.esm.js",
   "type": "module",
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,7 @@ export default [
         input: "src/lib/index.ts",
         output: {
             exports: "named",
-            file: "dist/lib.cjs.js",
+            file: "dist/lib.cjs",
             format: "cjs",
         },
         external: ["heresy", ...peerDependencies],


### PR DESCRIPTION
Seems like some bundlers, like the one included in Next@12, has problems parsing our files. This change makes the cjs build use the proper .cjs format to hopefully make it easier for such bundlers to use our package.

Fixes: https://github.com/whereby/browser-sdk/issues/51