### PR TITLE
Allow local-stack room urls

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 export default {
+    rootDir: "src",
     testEnvironment: "jest-environment-node",
     transform: {},
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,9 +7,6 @@ const replaceValues = {
     preventAssignment: true,
     values: {
         __SDK_VERSION__: pkg.version,
-        "process.env.STORYBOOK_SUBDOMAIN": null,
-        "process.env.STORYBOOK_ROOMKEY": null,
-        "process.env.STORYBOOK_BASEURL": null,
     },
 };
 

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -1,4 +1,6 @@
 import { html } from "lit-html";
+import { action } from "@storybook/addon-actions";
+
 import "./lib";
 
 export default {
@@ -47,30 +49,33 @@ const WherebyEmbed = ({
     recording,
     room,
     screenshare,
+    style,
     video,
     virtualBackgroundUrl,
 }) => {
-    return html`<whereby-embed
-        audio=${offOn(audio)}
-        avatarUrl=${avatarUrl}
-        background=${offOn(background)}
-        cameraAccess=${offOn(cameraAccess)}
-        chat=${offOn(chat)}
-        displayName=${displayName}
-        emptyRoomInvitation=${emptyRoomInvitation}
-        floatSelf=${offOn(floatSelf)}
-        help=${offOn(help)}
-        leaveButton=${offOn(leaveButton)}
-        logo=${offOn(logo)}
-        people=${offOn(people)}
-        precallReview=${offOn(precallReview)}
-        recording=${offOn(recording)}
-        screenshare=${offOn(screenshare)}
-        video=${offOn(video)}
-        virtualBackgroundUrl=${virtualBackgroundUrl}
-        room="${room}"
-        style="height: 100vh"
-    />`;
+    const el = document.createElement("whereby-embed");
+
+    el.setAttribute("audio", offOn(audio));
+    el.setAttribute("avatarUrl", avatarUrl);
+    el.setAttribute("background", offOn(background));
+    el.setAttribute("cameraAccess", offOn(cameraAccess));
+    el.setAttribute("chat", offOn(chat));
+    el.setAttribute("displayName", displayName);
+    el.setAttribute("emptyRoomInvitation", emptyRoomInvitation);
+    el.setAttribute("floatSelf", offOn(floatSelf));
+    el.setAttribute("help", offOn(help));
+    el.setAttribute("leaveButton", offOn(leaveButton));
+    el.setAttribute("logo", offOn(logo));
+    el.setAttribute("people", offOn(people));
+    el.setAttribute("precallReview", offOn(precallReview));
+    el.setAttribute("recording", recording);
+    el.setAttribute("screenshare", offOn(screenshare));
+    el.setAttribute("video", offOn(video));
+    el.setAttribute("virtualBackgroundUrl", virtualBackgroundUrl);
+    el.setAttribute("room", room);
+    el.setAttribute("style", style);
+
+    return el;
 };
 
 const Template = (args) => WherebyEmbed(args);
@@ -92,6 +97,7 @@ Primary.args = {
     precallReview: true,
     room: process.env.STORYBOOK_ROOM,
     screenshare: true,
+    style: "height: 100vh",
     video: true,
     virtualBackgroundUrl: "",
 };
@@ -102,4 +108,38 @@ Primary.parameters = {
             return (src || "").replace(/><iframe(.+)$/, " />");
         },
     },
+};
+
+export const Recording = (args) => {
+    const el = WherebyEmbed(args);
+    el.setAttribute("style", "height: 400px");
+
+    el.addEventListener("recording_status_change", (e) => {
+        action("recording_status_change")(e.detail);
+    });
+
+    return html`<div>
+        ${el}
+        <div>
+            <button
+                @click=${function a() {
+                    el.startRecording();
+                }}
+            >
+                Start recording
+            </button>
+            <button
+                @click=${function a() {
+                    el.stopRecording();
+                }}
+            >
+                Stop recording
+            </button>
+        </div>
+    </div>`;
+};
+
+Recording.args = {
+    ...Primary.args,
+    recording: "cloud",
 };

--- a/src/lib/helpers/__tests__/roomUrl.unit.js
+++ b/src/lib/helpers/__tests__/roomUrl.unit.js
@@ -1,0 +1,29 @@
+import { parseRoomUrlAndSubdomain } from "../roomUrl";
+
+describe("roomUrl", () => {
+    describe.only("parseRoomUrlAndSubdomain", () => {
+        it.each`
+            roomAttribute                                                     | subdomainAttribute | expectedRes
+            ${""}                                                             | ${undefined}       | ${new Error("Missing room attribute")}
+            ${"https://abc.whereby.com/room"}                                 | ${undefined}       | ${{ roomUrl: new URL("https://abc.whereby.com/room"), subdomain: "abc" }}
+            ${"https://abc.whereby.com/room?roomKey=123"}                     | ${undefined}       | ${{ roomUrl: new URL("https://abc.whereby.com/room?roomKey=123"), subdomain: "abc" }}
+            ${"https://abc-ip-127-0-0-1.hereby.dev:4443/room?roomKey=123"}    | ${undefined}       | ${{ roomUrl: new URL("https://abc-ip-127-0-0-1.hereby.dev:4443/room?roomKey=123"), subdomain: "abc" }}
+            ${"https://abc-ip-192-168-2-22.hereby.dev:4443/room?roomKey=123"} | ${undefined}       | ${{ roomUrl: new URL("https://abc-ip-192-168-2-22.hereby.dev:4443/room?roomKey=123"), subdomain: "abc" }}
+            ${"https://whereby.com/room"}                                     | ${undefined}       | ${new Error("Missing subdomain attribute")}
+            ${"https://abc.whereby.com"}                                      | ${"tt"}            | ${new Error("Could not parse room URL")}
+        `(
+            "should return $expectedRes when roomAttribute:$roomAttribute, subdomainAttribute:$subdomainAttribute",
+            ({ roomAttribute, subdomainAttribute, expectedRes }) => {
+                let res;
+
+                try {
+                    res = parseRoomUrlAndSubdomain(roomAttribute, subdomainAttribute);
+                } catch (error) {
+                    res = error;
+                }
+
+                expect(res).toEqual(expectedRes);
+            }
+        );
+    });
+});

--- a/src/lib/helpers/roomUrl.js
+++ b/src/lib/helpers/roomUrl.js
@@ -1,0 +1,23 @@
+export function parseRoomUrlAndSubdomain(roomAttribute, subdomainAttribute) {
+    if (!roomAttribute) {
+        throw new Error("Missing room attribute");
+    }
+
+    // Get subdomain from room URL, or use it specified
+    const m = /https:\/\/([^.]+)(\.whereby\.com|-ip-\d+-\d+-\d+-\d+.hereby.dev:4443)\/.+/.exec(roomAttribute);
+    const subdomain = (m && m[1]) || subdomainAttribute;
+
+    if (!subdomain) {
+        throw new Error("Missing subdomain attribute");
+    }
+    if (!m) {
+        throw new Error("Could not parse room URL");
+    }
+
+    const roomUrl = new URL(roomAttribute);
+
+    return {
+        subdomain,
+        roomUrl,
+    };
+}


### PR DESCRIPTION
This change allows for local-stack urls to be used when developing the `<whereby-embed />` element. 

**Tested like**
1. Start local-stack with PWA https://github.com/whereby/pwa/pull/3678
2. Make sure you have an Embedded account and a room with cloud recording configured
3. Also make sure to have `http://localhost:6006` in your "Allowed domains" list in the dashboard
4. In this repo, do `STORYBOOK_ROOM=<room_url> yarn dev`
5. Choose the "Recording" story and verify you can successfully connect to the room
6. Click "Start recording" in custom UI, verify recording starts
7. Click "Stop recording" in custom UI, verify recording stops
8. Verify you get events for recording status change (screenshot)

<img width="441" alt="Screenshot 2023-06-27 at 11 37 06" src="https://github.com/whereby/browser-sdk/assets/778534/595a7ee9-73ac-420e-a0eb-d735e04faca7">
