### PR TITLE
Add Storybook story for testing strict mode

### DIFF
--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -53,3 +53,23 @@ export const RoomConnectionOnly = ({ roomUrl, displayName }: { roomUrl: string; 
 
     return <VideoExperience displayName={displayName} roomName={roomUrl} />;
 };
+
+export const RoomConnectionStrictMode = ({ roomUrl, displayName }: { roomUrl: string; displayName?: string }) => {
+    if (!roomUrl || !roomUrl.match(roomRegEx)) {
+        return <p>Set room url on the Controls panel</p>;
+    }
+
+    return (
+        <React.StrictMode>
+            <VideoExperience displayName={displayName} roomName={roomUrl} />
+        </React.StrictMode>
+    );
+};
+
+RoomConnectionStrictMode.parameters = {
+    docs: {
+        source: {
+            code: "Disabled for this story, see https://github.com/storybookjs/storybook/issues/11554",
+        },
+    },
+};


### PR DESCRIPTION
We have some issues with our `useRoomConnection` hook lifecycle. Add separate story enforcing strict mode to allow for easy debugging.

**Tested like**
1. `STORYBOOK_ROOM=<your room url> yarn storybook`
2. Open "RoomConnectionStrictMode" story
3. Verify you get "Trying to join when room state is already connecting" in console