### PR TITLE
Make the React hooks work with React.StrictMode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha11",
+    "version": "2.0.0-alpha12",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -113,8 +113,8 @@ interface RoomEventsMap {
     waiting_participant_left: CustomEvent<WaitingParticipantLeftEvent>;
 }
 
-const API_BASE_URL = "https://api.whereby.dev";
-const SIGNAL_BASE_URL = "wss://signal.appearin.net";
+const API_BASE_URL = process.env["REACT_APP_API_BASE_URL"] || "https://api.whereby.dev";
+const SIGNAL_BASE_URL = process.env["REACT_APP_SIGNAL_BASE_URL"] || "wss://signal.appearin.net";
 
 const NON_PERSON_ROLES = ["recorder", "streamer"];
 

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -123,6 +123,7 @@ function createSocket() {
     const SOCKET_HOST = parsedUrl.origin;
 
     const socketConf = {
+        autoConnect: false,
         host: SOCKET_HOST,
         path,
         reconnectionDelay: 5000,
@@ -543,6 +544,7 @@ export default class RoomConnection extends TypedEventTarget {
         }
 
         this.logger.log("Joining room");
+        this.signalSocket.connect();
         this.roomConnectionStatus = "connecting";
         this.dispatchEvent(
             new CustomEvent("room_connection_status_changed", {


### PR DESCRIPTION
Using the `useRoomConnection` hook with a React `<StrictMode>` [wrapper component](https://react.dev/reference/react/StrictMode) ended up creating duplicated signal connections and broken join/leave room function calls.

The solution was to only create the socket connection when the `join()` fn is called and we also had to reorganize the `leave()` and `join()` functions a bit.

### Test plan

1. Start StoryBook `yarn storybook`
2. Make sure all components work and able to join a room, including the `RoomConnectionStrictMode` one (which does not work without this change).