### PR TITLE
Include assert dependency in bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ The `useLocalMedia` hook enables preview and selection of local devices (camera 
 experiences, allowing end users to confirm their device selection up-front. This hook works seamlessly with the `useRoomConnection` hook described below.
 
 ```js
-import { useLocalMedia, VideoView } from “@whereby.com/browser-sdk”;
+import { useLocalMedia, VideoView } from "@whereby.com/browser-sdk";
 
 function MyPreCallUX() {
     const localMedia = useLocalMedia({ audio: false, video: true });
 
     const { currentCameraDeviceId, cameraDevices, localStream } = localMedia.state;
     const { setCameraDevice, toggleCameraEnabled } = localMedia.actions;
-    const { VideoView } = components;
 
     return <div className="preCallView">
         { /* Render any UI, making use of state */ }
@@ -62,7 +61,7 @@ function MyPreCallUX() {
 The `useRoomConnection` hook provides a way to connect participants in a given room, subscribe to state updates, and perform actions on the connection, like toggling camera or microphone.
 
 ```js
-import { useRoomConnection } from “@whereby.com/browser-sdk”;
+import { useRoomConnection } from "@whereby.com/browser-sdk";
 
 function MyCallUX( { roomUrl, localStream }) {
     const { state, actions, components } = useRoomConnection(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha12",
+    "version": "2.0.0-alpha13",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,10 @@ const replaceValues = {
     preventAssignment: true,
     values: {
         __SDK_VERSION__: pkg.version,
+        "process.env.NODE_DEBUG": JSON.stringify(process.env.NODE_DEBUG),
+        "process.env.AWF_BASE_URL": JSON.stringify(process.env.AWF_BASE_URL),
+        "process.env.AWF_API_BASE_URL": JSON.stringify(process.env.AWF_API_BASE_URL),
+        "process.env.AP_ROOM_BASE_URL": JSON.stringify(process.env.AP_ROOM_BASE_URL),
     },
 };
 
@@ -28,6 +32,13 @@ function makeCdnFilename() {
     return `v${major}${tag}.js`;
 }
 
+const plugins = [
+    replace(replaceValues),
+    nodeResolve({ preferBuiltins: false, resolveOnly: [/jslib-media|assert|util/] }),
+    commonjs(),
+    typescript(),
+];
+
 export default [
     // Commonjs build of lib, to be used with bundlers
     {
@@ -38,7 +49,7 @@ export default [
             format: "cjs",
         },
         external: ["heresy", ...peerDependencies],
-        plugins: [nodeResolve({ resolveOnly: [/jslib-media/] }), replace(replaceValues), typescript()],
+        plugins,
     },
     // Esm build of lib, to be used with bundlers
     {
@@ -49,7 +60,7 @@ export default [
             format: "esm",
         },
         external: ["heresy", ...peerDependencies],
-        plugins: [nodeResolve({ resolveOnly: [/jslib-media/] }), replace(replaceValues), typescript()],
+        plugins,
     },
     // Legacy build of lib in ESM format, bundling the dependencies
     {


### PR DESCRIPTION
We are seeing some issues using the SDK in Vite projects, most likely down to a Vite issue
[https://github.com/browserify/commonjs-assert/issues/56#issuecomment-1286456457]. However, we are choosing to "fix" it internally for now to reduce friction.

**Tested like**
1. Create a new Vite project
2. Build this and do `yalc publish`
3. `yalc add` in the Vite project and import `useLocalMedia`
4. Render your local video, make sure it works