### PR TITLE
Reporting resolution to the SFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # `@whereby.com/browser-sdk`
 
-> This is a pre-release of the v2 version of this library, adding support for more custom integration using React hooks and plain JavaScript classes in addition to the web component for embedding.
+> This is a pre-release of the v2 version of this library, adding support for
+> more custom integration using React hooks and plain JavaScript classes in
+> addition to the web component for embedding.
 
-Whereby browser SDK is a library for seamless integration of Whereby (https://whereby.com) video calls into your web application.
+Whereby browser SDK is a library for seamless integration of Whereby
+(https://whereby.com) video calls into your web application.
 
 ## Installation
 
@@ -18,14 +21,19 @@ yarn add @whereby.com/browser-sdk
 
 ## Usage
 
-> In order to make use of this functionality, you must have a Whereby account from which you can create room urls, either [manually or through our API](https://docs.whereby.com/creating-and-deleting-rooms).
+> In order to make use of this functionality, you must have a Whereby account
+> from which you can create room urls, either [manually or through our
+> API](https://docs.whereby.com/creating-and-deleting-rooms).
 
 ### React hooks
 
 #### useLocalMedia
 
-The `useLocalMedia` hook enables preview and selection of local devices (camera & microphone) prior to establishing a connection within a Whereby room. Use this hook to build rich pre-call
-experiences, allowing end users to confirm their device selection up-front. This hook works seamlessly with the `useRoomConnection` hook described below.
+The `useLocalMedia` hook enables preview and selection of local devices (camera
+& microphone) prior to establishing a connection within a Whereby room. Use
+this hook to build rich pre-call experiences, allowing end users to confirm
+their device selection up-front. This hook works seamlessly with the
+`useRoomConnection` hook described below.
 
 ```js
 import { useLocalMedia, VideoView } from "@whereby.com/browser-sdk";
@@ -58,7 +66,9 @@ function MyPreCallUX() {
 
 #### useRoomConnection
 
-The `useRoomConnection` hook provides a way to connect participants in a given room, subscribe to state updates, and perform actions on the connection, like toggling camera or microphone.
+The `useRoomConnection` hook provides a way to connect participants in a given
+room, subscribe to state updates, and perform actions on the connection, like
+toggling camera or microphone.
 
 ```js
 import { useRoomConnection } from "@whereby.com/browser-sdk";
@@ -89,10 +99,12 @@ function MyCallUX( { roomUrl, localStream }) {
 
 ```
 
-##### Usage with Next.js
-If you are integrating these React hooks with Next.js, you need to ensure your custom video experience components are
-reneded client side, as the underlying APIs we use are only available in the browser context. Simply add `"use client";`
-to the top of component, like in the following example:
+#### Usage with Next.js
+
+If you are integrating these React hooks with Next.js, you need to ensure your
+custom video experience components are rendered client side, as the underlying
+APIs we use are only available in the browser context. Simply add `"use
+client";` to the top of component, like in the following example:
 
 ```js
 "use client";
@@ -111,7 +123,10 @@ export default function MyNextVideoExperience() {
 
 ### Web component for embedding
 
-Use the `<whereby-embed />` web component to make use of Whereby's pre-built responsive UI. Refer to our [documentation](https://docs.whereby.com/embedding-rooms/in-a-web-page/using-the-whereby-embed-element) to learn which attributes are supported.
+Use the `<whereby-embed />` web component to make use of Whereby's pre-built
+responsive UI. Refer to our
+[documentation](https://docs.whereby.com/embedding-rooms/in-a-web-page/using-the-whereby-embed-element)
+to learn which attributes are supported.
 
 #### React
 
@@ -142,4 +157,6 @@ export default MyComponent;
 
 **Note**
 
-Although we have just higlighted two combinations of how to load and use the web component, it should be possible to use this library with all the major frontend frameworks.
+Although we have just higlighted two combinations of how to load and use the
+web component, it should be possible to use this library with all the major
+frontend frameworks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha17",
+    "version": "2.0.0-alpha18",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/react/VideoView.tsx
+++ b/src/lib/react/VideoView.tsx
@@ -1,15 +1,45 @@
 import React, { useEffect, useRef } from "react";
+import debounce from "../utils/debounce";
 
 interface VideoViewSelfProps {
     stream: MediaStream;
+    muted?: boolean;
     style?: React.CSSProperties;
+    onResize?: ({ width, height, stream }: { width: number; height: number; stream: MediaStream }) => void;
 }
 
 type VideoViewProps = VideoViewSelfProps &
     React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
 
-export default ({ muted, stream, ...rest }: VideoViewProps) => {
+export default ({ muted, stream, onResize, ...rest }: VideoViewProps) => {
     const videoEl = useRef<HTMLVideoElement>(null);
+
+    useEffect(() => {
+        if (!videoEl.current || !onResize) {
+            return;
+        }
+
+        const resizeObserver = new ResizeObserver(
+            debounce(
+                () => {
+                    if (videoEl.current && stream?.id) {
+                        onResize({
+                            width: videoEl.current.clientWidth,
+                            height: videoEl.current.clientHeight,
+                            stream,
+                        });
+                    }
+                },
+                { delay: 1000, edges: true }
+            )
+        );
+
+        resizeObserver.observe(videoEl.current);
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, [stream]);
 
     useEffect(() => {
         if (!videoEl.current) {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useState } from "react";
+import React, { useEffect, useReducer, useState } from "react";
 import VideoView from "./VideoView";
 import { LocalMediaRef } from "./useLocalMedia";
 import RoomConnection, {
@@ -328,8 +328,10 @@ interface RoomConnectionActions {
     rejectWaitingParticipant(participantId: string): void;
 }
 
+type VideoViewComponentProps = Omit<React.ComponentProps<typeof VideoView>, "onResize">;
+
 interface RoomConnectionComponents {
-    VideoView: typeof VideoView;
+    VideoView: (props: VideoViewComponentProps) => ReturnType<typeof VideoView>;
 }
 
 export type RoomConnectionRef = {
@@ -471,7 +473,27 @@ export default function useRoomConnection(
             },
         },
         components: {
-            VideoView,
+            VideoView: (props: VideoViewComponentProps): JSX.Element =>
+                React.createElement(
+                    VideoView as React.ComponentType<VideoViewComponentProps>,
+                    Object.assign({}, props, {
+                        onResize: ({
+                            stream,
+                            width,
+                            height,
+                        }: {
+                            stream: MediaStream;
+                            width: number;
+                            height: number;
+                        }) => {
+                            roomConnection.updateStreamResolution({
+                                streamId: stream.id,
+                                width,
+                                height,
+                            });
+                        },
+                    })
+                ),
         },
         _ref: roomConnection,
     };

--- a/src/lib/utils/__tests__/debounce.spec.ts
+++ b/src/lib/utils/__tests__/debounce.spec.ts
@@ -1,0 +1,94 @@
+import { jest } from "@jest/globals";
+
+import debounce from "../debounce";
+
+jest.useFakeTimers();
+
+describe("debounce", () => {
+    let fn: jest.Mock;
+
+    beforeEach(() => {
+        fn = jest.fn();
+        jest.spyOn(global, "setTimeout");
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should throw if no function is provided", () => {
+        expect(() => {
+            // @ts-expect-error
+            debounce();
+        }).toThrow("fn<function> is required");
+    });
+
+    it("should set the timer with the specified delay", () => {
+        const delay = Math.floor(Math.random() * 2000);
+
+        const debouncedFn = debounce(fn, { delay });
+        debouncedFn();
+
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), delay);
+    });
+
+    it("should call the debounced function only after the delay has passed", () => {
+        const debouncedFn = debounce(fn);
+
+        debouncedFn();
+        expect(fn).not.toHaveBeenCalled();
+
+        jest.runAllTimers();
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call the debounced function with the provided arguments", () => {
+        const arg1 = {};
+        const arg2 = Math.random();
+        const debouncedFn = debounce(fn);
+
+        debouncedFn(arg1, arg2);
+        jest.runAllTimers();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith(arg1, arg2);
+    });
+
+    it("should call the debounced function only once", () => {
+        const debouncedFn = debounce(fn);
+
+        debouncedFn();
+        debouncedFn();
+
+        jest.runAllTimers();
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    describe("with edges: true", () => {
+        it("should call the debounced function first and then once more at end", () => {
+            const debouncedFn = debounce(fn, { edges: true });
+
+            debouncedFn();
+            debouncedFn();
+            debouncedFn();
+            debouncedFn();
+
+            expect(fn).toHaveBeenCalledTimes(1);
+            jest.runAllTimers();
+            expect(fn).toHaveBeenCalledTimes(2);
+        });
+
+        it("should call the debounced function again after time has elapsed", () => {
+            const debouncedFn = debounce(fn, { edges: true });
+
+            debouncedFn();
+            expect(fn).toHaveBeenCalledTimes(1);
+            jest.runAllTimers();
+            expect(fn).toHaveBeenCalledTimes(1);
+            debouncedFn();
+
+            expect(fn).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,0 +1,43 @@
+import assert from "assert";
+
+interface Options {
+    delay?: number;
+    edges?: boolean;
+}
+
+interface DebouncedFunction {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (...args: any[]): void;
+}
+
+/**
+ * Debounce function.
+ *
+ * @param {Function} fn - Function to debounce.
+ * @param {Object} [options] - Options.
+ * @param {number} [options.delay=500] - Delay in milliseconds.
+ * @param {boolean} [options.edges=false] - Whether to call the function on the
+ * leading and trailing edges of the wait timeout.
+ * @returns {Function} Debounced function.
+ */
+export default function debounce(fn: DebouncedFunction, { delay = 500, edges }: Options = {}): DebouncedFunction {
+    assert.ok(typeof fn === "function", "fn<function> is required");
+
+    let timeout: NodeJS.Timeout | undefined;
+    let nCalls = 0;
+
+    return (...args) => {
+        nCalls += 1;
+        if (edges && nCalls === 1) {
+            fn(...args);
+        }
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+            if (!edges || nCalls > 1) {
+                fn(...args);
+            }
+            timeout = undefined;
+            nCalls = 0;
+        }, delay);
+    };
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -77,6 +77,7 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManager" {
         disconnectAll(): void;
         replaceTrack(oldTrack: MediaStreamTrack, newTrack: MediaStreamTrack): Promise<void>;
         shouldAcceptStreamsFromBothSides?: () => boolean;
+        updateStreamResolution(streamId: string, ignored: null, resolution: { width: number; height: number }): void;
     }
 }
 


### PR DESCRIPTION
SFU can return the streams in the requested size, so no need to download a bigger resolution if the video view is small. The size change is reported when the video's width or height changes, but there's a debounce wrapper on the reporter with 1 sec delay to avoid sending too many reqs.

### Testing

1. Set up a meeting where remote participant's video has dynamic size, e.g. with `style={ width: "100%" }`
2. Resize the box of the remote participant's video
3. See the quality difference:
    * if you set a low width and zoom in => you should see a lower quality
    * then if you quickly increase the video size => you should still see the a lower quality for up to 1sec, then it should use a nice quality

### Gotchas

#### Low quality on small resolutions

It seems the remote participant's frame rate is very low on small resolutions.

|branch| pwa at 640x360 | pwa at 320x180 | sdk at 640x360 | sdk at 320x180 |
| -- | -- | -- | -- | -- |
|development | N/A | 29-30fps | 14-15fps | N/A (it always gets 360p) |
| current | N/A | 29-30fps | 14-15fps | **7fps** |

SDK's default remote participant res is 360p, and it's the same on the current branch. Changing the resolution to a small one the frame rate drops to 7fps, which looks quite bad. This is not visible on development branch as we do not report the video size to SFU so it always downloads the 360p, even if it is rendered in a 10x10px box.

I compared the `RtcManagerDispatcher`'s features in pwa and sdk and they're the same.

#### Only report resolution from the connected component

The `VideoView` must be imported via the `useRoomConnection` to get this feature. Currently it can be imported 2 ways:

```js
// directly from the browser-sdk pkg
import { useRoomConnection, VideoView} from "@whereby.com/browser-sdk"
```
```js
// or via the useRoomConnection hook
import { useRoomConnection } from "@whereby.com/browser-sdk"

function MyUX(){
    const roomConnection = useRoomConnection(roomUrl, {
        localMedia: null,
        localMediaConstraints: localMedia,
        displayName,
        logger: console,
    });
    const { VideoView } = roomConnection.components;
}
```

The SFU reporting only works if it is imported on the 2nd way, as we inject the `roomConnection` as prop to the roomConnection.component's `VideoView`.

I was not sure if we should keep the direct `VideoView` export as it might be less performant. But it can still be used for local media streams and related stories. + Removing it would be a breaking change, although this might not be a problem in alpha versions.