### PR TITLE
Remote screenshare support

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@swc/helpers": "^0.3.13",
-        "@whereby/jslib-media": "whereby/jslib-media.git#0.2.0",
+        "@whereby/jslib-media": "whereby/jslib-media.git#0.2.1",
         "assert": "^2.0.0",
         "axios": "^1.2.3",
         "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha15",
+    "version": "2.0.0-alpha16",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/RoomParticipant.ts
+++ b/src/lib/RoomParticipant.ts
@@ -60,6 +60,17 @@ export class RemoteParticipant extends RoomParticipant {
         this.streams = streams.map((streamId) => ({ id: streamId, state: newJoiner ? "new_accept" : "to_accept" }));
     }
 
+    addStream(streamId: string, state: StreamState) {
+        this.streams.push({ id: streamId, state });
+    }
+
+    removeStream(streamId: string) {
+        const index = this.streams.findIndex((s) => s.id === streamId);
+        if (index !== -1) {
+            this.streams.splice(index, 1);
+        }
+    }
+
     updateStreamState(streamId: string, state: StreamState) {
         const stream = this.streams.find((s) => s.id === streamId);
         if (stream) {
@@ -79,4 +90,18 @@ export class LocalParticipant extends RoomParticipant {
 export interface WaitingParticipant {
     id: string;
     displayName: string | null;
+}
+
+export class Screenshare {
+    public readonly participantId: string;
+    public readonly id: string;
+    public readonly hasAudioTrack: boolean;
+    public readonly stream?: MediaStream;
+
+    constructor({ participantId, id, hasAudioTrack, stream }: Screenshare) {
+        this.participantId = participantId;
+        this.id = id;
+        this.hasAudioTrack = hasAudioTrack;
+        this.stream = stream;
+    }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -33,6 +33,7 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManagerDispatcher" {
         clientId: string;
         stream: MediaStream;
         streamId: string;
+        streamType: "webcam" | "screenshare";
     }
 
     type RtcEvents = {
@@ -177,6 +178,17 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         liveVideo: boolean;
     }
 
+    interface ScreenshareStartedEvent {
+        clientId: string;
+        streamId: string;
+        hasAudioTrack: boolean;
+    }
+
+    interface ScreenshareStoppedEvent {
+        clientId: string;
+        streamId: string;
+    }
+
     interface VideoEnabledEvent {
         clientId: string;
         isVideoEnabled: boolean;
@@ -204,6 +216,8 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         room_joined: RoomJoinedEvent;
         room_knocked: RoomKnockedEvent;
         room_left: void;
+        screenshare_started: ScreenshareStartedEvent;
+        screenshare_stopped: ScreenshareStoppedEvent;
         streaming_stopped: void;
         video_enabled: VideoEnabledEvent;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3686,9 +3686,9 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whereby/jslib-media@whereby/jslib-media.git#0.2.0":
-  version "0.2.0"
-  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/2e0354ca8c76810e710282f8051e08bde482090f"
+"@whereby/jslib-media@whereby/jslib-media.git#0.2.1":
+  version "0.2.1"
+  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/c728ca326eaeab8dc1b2aa4b67c0130f0a17bdb6"
   dependencies:
     assert "^2.0.0"
     mediasoup-client "^3.6.82"


### PR DESCRIPTION
This adds support for rendering remote screenshares, with a new property on the `state` object, containing a list of active screenshares. This allows you to render screenshares separately from normal videos:

```js
 const { remoteParticipants, screenshares } = state;
 
       {remoteParticipants.map((p) => (
        <VideoView key={p.id} stream={p.stream} />
      ))}

      {screenshares.map((s) => (
        <VideoView key={s.id} stream={s.stream} />
      ))}
```

The screenshares are also added as a stream in the `streams` array of the remote participant - and there's some cleanup to the `addStream` functionality. This fixes the bug where we render the screenshare as a participant stream if you join a room with the SDK where a screenshare is already active.

Local screenshare (render/start/stop) is not handled in this PR, it will come in a follow-up.

Screenshares are currently shown twice - this is because of a known bug with the event listeners.

### Test plan

1. Add the relevant code to you SDK test app - as shown above
2. Join a room with an sdk client and a remote participant
3. Start a screenshare with the remote participant, you should see the screenshare rendered in the SDK app
4. Leave and join again with the SDK app - you should see both the video and screenshare view from the remote participant
5. Stop screenshare, it should go away and the video of the remote participant should stay.