### PR TITLE
Make use of new jslib-media version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha16",
+    "version": "2.0.0-alpha17",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@swc/helpers": "^0.3.13",
-        "@whereby/jslib-media": "whereby/jslib-media.git#0.2.1",
+        "@whereby/jslib-media": "whereby/jslib-media.git#0.2.2",
         "assert": "^2.0.0",
         "axios": "^1.2.3",
         "btoa": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3686,9 +3686,9 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whereby/jslib-media@whereby/jslib-media.git#0.2.1":
-  version "0.2.1"
-  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/c728ca326eaeab8dc1b2aa4b67c0130f0a17bdb6"
+"@whereby/jslib-media@whereby/jslib-media.git#0.2.2":
+  version "0.2.2"
+  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/98ad53d8570ee20738763759d2726e7979f8beac"
   dependencies:
     assert "^2.0.0"
     mediasoup-client "^3.6.82"


### PR DESCRIPTION
Update dependency to make use of latest version.

**Tested like**
1. `yarn install`, validate the updated dependency gets installed
2. Verify functionality works as expected

**Notes**
Will update the dependency version once the jslib-media PR is merged and deployed.
