### PR TITLE
Clean up event listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha18",
+    "version": "2.0.0-alpha19",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -67,66 +67,66 @@ export type StreamingState = {
     startedAt: number | null;
 };
 
-type RoomJoinedEvent = {
+export type RoomJoinedEvent = {
     localParticipant: LocalParticipant;
     remoteParticipants: RemoteParticipant[];
     waitingParticipants: WaitingParticipant[];
 };
 
-type RoomConnectionStatusChangedEvent = {
+export type RoomConnectionStatusChangedEvent = {
     roomConnectionStatus: RoomConnectionStatus;
 };
 
-type ParticipantJoinedEvent = {
+export type ParticipantJoinedEvent = {
     remoteParticipant: RemoteParticipant;
 };
 
-type ParticipantLeftEvent = {
+export type ParticipantLeftEvent = {
     participantId: string;
 };
 
-type ParticipantStreamAddedEvent = {
+export type ParticipantStreamAddedEvent = {
     participantId: string;
     stream: MediaStream;
 };
 
-type ParticipantAudioEnabledEvent = {
+export type ParticipantAudioEnabledEvent = {
     participantId: string;
     isAudioEnabled: boolean;
 };
 
-type ParticipantVideoEnabledEvent = {
+export type ParticipantVideoEnabledEvent = {
     participantId: string;
     isVideoEnabled: boolean;
 };
 
-type ParticipantMetadataChangedEvent = {
+export type ParticipantMetadataChangedEvent = {
     participantId: string;
     displayName: string;
 };
 
-type ScreenshareStartedEvent = {
+export type ScreenshareStartedEvent = {
     participantId: string;
     id: string;
     hasAudioTrack: boolean;
     stream: MediaStream;
 };
 
-type ScreenshareStoppedEvent = {
+export type ScreenshareStoppedEvent = {
     participantId: string;
     id: string;
 };
 
-type WaitingParticipantJoinedEvent = {
+export type WaitingParticipantJoinedEvent = {
     participantId: string;
     displayName: string | null;
 };
 
-type WaitingParticipantLeftEvent = {
+export type WaitingParticipantLeftEvent = {
     participantId: string;
 };
 
-interface RoomEventsMap {
+export interface RoomEventsMap {
     chat_message: CustomEvent<ChatMessage>;
     cloud_recording_started: CustomEvent<CloudRecordingState>;
     participant_audio_enabled: CustomEvent<ParticipantAudioEnabledEvent>;

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -127,21 +127,23 @@ export type WaitingParticipantLeftEvent = {
 };
 
 export interface RoomEventsMap {
-    chat_message: CustomEvent<ChatMessage>;
-    cloud_recording_started: CustomEvent<CloudRecordingState>;
-    participant_audio_enabled: CustomEvent<ParticipantAudioEnabledEvent>;
-    participant_joined: CustomEvent<ParticipantJoinedEvent>;
-    participant_left: CustomEvent<ParticipantLeftEvent>;
-    participant_metadata_changed: CustomEvent<ParticipantMetadataChangedEvent>;
-    participant_stream_added: CustomEvent<ParticipantStreamAddedEvent>;
-    participant_video_enabled: CustomEvent<ParticipantVideoEnabledEvent>;
-    room_connection_status_changed: CustomEvent<RoomConnectionStatusChangedEvent>;
-    room_joined: CustomEvent<RoomJoinedEvent>;
-    screenshare_started: CustomEvent<ScreenshareStartedEvent>;
-    screenshare_stopped: CustomEvent<ScreenshareStoppedEvent>;
-    streaming_started: CustomEvent<StreamingState>;
-    waiting_participant_joined: CustomEvent<WaitingParticipantJoinedEvent>;
-    waiting_participant_left: CustomEvent<WaitingParticipantLeftEvent>;
+    chat_message: (e: CustomEvent<ChatMessage>) => void;
+    cloud_recording_started: (e: CustomEvent<CloudRecordingState>) => void;
+    cloud_recording_stopped: (e: CustomEvent<CloudRecordingState>) => void;
+    participant_audio_enabled: (e: CustomEvent<ParticipantAudioEnabledEvent>) => void;
+    participant_joined: (e: CustomEvent<ParticipantJoinedEvent>) => void;
+    participant_left: (e: CustomEvent<ParticipantLeftEvent>) => void;
+    participant_metadata_changed: (e: CustomEvent<ParticipantMetadataChangedEvent>) => void;
+    participant_stream_added: (e: CustomEvent<ParticipantStreamAddedEvent>) => void;
+    participant_video_enabled: (e: CustomEvent<ParticipantVideoEnabledEvent>) => void;
+    room_connection_status_changed: (e: CustomEvent<RoomConnectionStatusChangedEvent>) => void;
+    room_joined: (e: CustomEvent<RoomJoinedEvent>) => void;
+    screenshare_started: (e: CustomEvent<ScreenshareStartedEvent>) => void;
+    screenshare_stopped: (e: CustomEvent<ScreenshareStoppedEvent>) => void;
+    streaming_started: (e: CustomEvent<StreamingState>) => void;
+    streaming_stopped: (e: CustomEvent<StreamingState>) => void;
+    waiting_participant_joined: (e: CustomEvent<WaitingParticipantJoinedEvent>) => void;
+    waiting_participant_left: (e: CustomEvent<WaitingParticipantLeftEvent>) => void;
 }
 
 const API_BASE_URL = process.env["REACT_APP_API_BASE_URL"] || "https://api.whereby.dev";
@@ -177,7 +179,7 @@ function createSocket() {
 interface RoomEventTarget extends EventTarget {
     addEventListener<K extends keyof RoomEventsMap>(
         type: K,
-        listener: (ev: RoomEventsMap[K]) => void,
+        listener: RoomEventsMap[K],
         options?: boolean | AddEventListenerOptions
     ): void;
     addEventListener(
@@ -187,7 +189,7 @@ interface RoomEventTarget extends EventTarget {
     ): void;
     removeEventListener<K extends keyof RoomEventsMap>(
         type: K,
-        listener: (ev: RoomEventsMap[K]) => void,
+        listener: RoomEventsMap[K],
         options?: boolean | EventListenerOptions
     ): void;
     removeEventListener(

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -185,6 +185,16 @@ interface RoomEventTarget extends EventTarget {
         callback: EventListenerOrEventListenerObject | null,
         options?: EventListenerOptions | boolean
     ): void;
+    removeEventListener<K extends keyof RoomEventsMap>(
+        type: K,
+        listener: (ev: RoomEventsMap[K]) => void,
+        options?: boolean | EventListenerOptions
+    ): void;
+    removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: EventListenerOptions | boolean
+    ): void;
 }
 
 const noop = () => {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -508,6 +508,9 @@ export default function useRoomConnection(
         roomConnection.join();
 
         return () => {
+            eventListeners.forEach(({ eventName, listener }) => {
+                roomConnection.removeEventListener(eventName, listener);
+            });
             roomConnection.leave();
         };
     }, []);

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -4,22 +4,10 @@ import { LocalMediaRef } from "./useLocalMedia";
 import RoomConnection, {
     ChatMessage,
     CloudRecordingState,
-    ParticipantAudioEnabledEvent,
-    ParticipantJoinedEvent,
-    ParticipantLeftEvent,
-    ParticipantMetadataChangedEvent,
-    ParticipantStreamAddedEvent,
-    ParticipantVideoEnabledEvent,
     RoomConnectionOptions,
     RoomConnectionStatus,
-    RoomConnectionStatusChangedEvent,
     RoomEventsMap,
-    RoomJoinedEvent,
-    ScreenshareStartedEvent,
-    ScreenshareStoppedEvent,
     StreamingState,
-    WaitingParticipantJoinedEvent,
-    WaitingParticipantLeftEvent,
 } from "../RoomConnection";
 import { LocalParticipant, RemoteParticipant, Screenshare, WaitingParticipant } from "../RoomParticipant";
 
@@ -354,8 +342,6 @@ export type RoomConnectionRef = {
     _ref: RoomConnection;
 };
 
-type RoomEventListener<T extends keyof RoomEventsMap> = (e: RoomEventsMap[T]) => void;
-
 export default function useRoomConnection(
     roomUrl: string,
     roomConnectionOptions: UseRoomConnectionOptions
@@ -369,134 +355,103 @@ export default function useRoomConnection(
     );
     const [state, dispatch] = useReducer(reducer, initialState);
 
+    type EventListener<K extends keyof RoomEventsMap> = {
+        eventName: K;
+        listener: RoomEventsMap[K];
+        options?: boolean | AddEventListenerOptions;
+    };
+
+    function createEventListener<K extends keyof RoomEventsMap>(
+        eventName: K,
+        listener: RoomEventsMap[K],
+        options?: boolean | AddEventListenerOptions
+    ): EventListener<K> {
+        return {
+            eventName,
+            listener,
+            options,
+        };
+    }
+
     const eventListeners = React.useMemo(
-        () =>
-            [
-                {
-                    eventName: "chat_message",
-                    listener: (e) => {
-                        const chatMessage = e.detail as ChatMessage;
-                        dispatch({ type: "CHAT_MESSAGE", payload: chatMessage });
-                    },
-                },
-                {
-                    eventName: "cloud_recording_started",
-                    listener: (e) => {
-                        const { status, startedAt } = e.detail as CloudRecordingState;
-                        dispatch({ type: "CLOUD_RECORDING_STARTED", payload: { status, startedAt } });
-                    },
-                },
-                {
-                    eventName: "cloud_recording_stopped",
-                    listener: () => {
-                        dispatch({ type: "CLOUD_RECORDING_STOPPED" });
-                    },
-                },
-                {
-                    eventName: "participant_audio_enabled",
-                    listener: (e) => {
-                        const { participantId, isAudioEnabled } = e.detail as ParticipantAudioEnabledEvent;
-                        dispatch({ type: "PARTICIPANT_AUDIO_ENABLED", payload: { participantId, isAudioEnabled } });
-                    },
-                },
-                {
-                    eventName: "participant_joined",
-                    listener: (e) => {
-                        const { remoteParticipant } = e.detail as ParticipantJoinedEvent;
-                        dispatch({ type: "PARTICIPANT_JOINED", payload: { paritipant: remoteParticipant } });
-                    },
-                },
-                {
-                    eventName: "participant_left",
-                    listener: (e) => {
-                        const { participantId } = e.detail as ParticipantLeftEvent;
-                        dispatch({ type: "PARTICIPANT_LEFT", payload: { participantId } });
-                    },
-                },
-                {
-                    eventName: "participant_metadata_changed",
-                    listener: (e) => {
-                        const { participantId, displayName } = e.detail as ParticipantMetadataChangedEvent;
-                        dispatch({ type: "PARTICIPANT_METADATA_CHANGED", payload: { participantId, displayName } });
-                    },
-                },
-                {
-                    eventName: "participant_stream_added",
-                    listener: (e) => {
-                        const { participantId, stream } = e.detail as ParticipantStreamAddedEvent;
-                        dispatch({ type: "PARTICIPANT_STREAM_ADDED", payload: { participantId, stream } });
-                    },
-                },
-                {
-                    eventName: "participant_video_enabled",
-                    listener: (e) => {
-                        const { participantId, isVideoEnabled } = e.detail as ParticipantVideoEnabledEvent;
-                        dispatch({ type: "PARTICIPANT_VIDEO_ENABLED", payload: { participantId, isVideoEnabled } });
-                    },
-                },
-                {
-                    eventName: "room_connection_status_changed",
-                    listener: (e) => {
-                        const { roomConnectionStatus } = e.detail as RoomConnectionStatusChangedEvent;
-                        dispatch({ type: "ROOM_CONNECTION_STATUS_CHANGED", payload: { roomConnectionStatus } });
-                    },
-                },
-                {
-                    eventName: "room_joined",
-                    listener: (e) => {
-                        const { localParticipant, remoteParticipants, waitingParticipants } =
-                            e.detail as RoomJoinedEvent;
-                        dispatch({
-                            type: "ROOM_JOINED",
-                            payload: { localParticipant, remoteParticipants, waitingParticipants },
-                        });
-                    },
-                },
-                {
-                    eventName: "screenshare_started",
-                    listener: (e) => {
-                        const { participantId, id, hasAudioTrack, stream } = e.detail as ScreenshareStartedEvent;
-                        dispatch({
-                            type: "SCREENSHARE_STARTED",
-                            payload: { participantId, id, hasAudioTrack, stream },
-                        });
-                    },
-                },
-                {
-                    eventName: "screenshare_stopped",
-                    listener: (e) => {
-                        const { participantId, id } = e.detail as ScreenshareStoppedEvent;
-                        dispatch({ type: "SCREENSHARE_STOPPED", payload: { participantId, id } });
-                    },
-                },
-                {
-                    eventName: "streaming_started",
-                    listener: (e) => {
-                        const { status, startedAt } = e.detail as StreamingState;
-                        dispatch({ type: "STREAMING_STARTED", payload: { status, startedAt } });
-                    },
-                },
-                {
-                    eventName: "streaming_stopped",
-                    listener: () => {
-                        dispatch({ type: "STREAMING_STOPPED" });
-                    },
-                },
-                {
-                    eventName: "waiting_participant_joined",
-                    listener: (e) => {
-                        const { participantId, displayName } = e.detail as WaitingParticipantJoinedEvent;
-                        dispatch({ type: "WAITING_PARTICIPANT_JOINED", payload: { participantId, displayName } });
-                    },
-                },
-                {
-                    eventName: "waiting_participant_left",
-                    listener: (e) => {
-                        const { participantId } = e.detail as WaitingParticipantLeftEvent;
-                        dispatch({ type: "WAITING_PARTICIPANT_LEFT", payload: { participantId } });
-                    },
-                },
-            ] as { eventName: keyof RoomEventsMap; listener: RoomEventListener<keyof RoomEventsMap> }[],
+        (): EventListener<keyof RoomEventsMap>[] => [
+            createEventListener("chat_message", (e) => {
+                dispatch({ type: "CHAT_MESSAGE", payload: e.detail });
+            }),
+            createEventListener("cloud_recording_started", (e) => {
+                const { status, startedAt } = e.detail;
+                dispatch({ type: "CLOUD_RECORDING_STARTED", payload: { status, startedAt } });
+            }),
+            createEventListener("cloud_recording_stopped", () => {
+                dispatch({ type: "CLOUD_RECORDING_STOPPED" });
+            }),
+            createEventListener("participant_audio_enabled", (e) => {
+                const { participantId, isAudioEnabled } = e.detail;
+                dispatch({ type: "PARTICIPANT_AUDIO_ENABLED", payload: { participantId, isAudioEnabled } });
+            }),
+            createEventListener("participant_joined", (e) => {
+                const { remoteParticipant } = e.detail;
+                dispatch({ type: "PARTICIPANT_JOINED", payload: { paritipant: remoteParticipant } });
+            }),
+            createEventListener("participant_left", (e) => {
+                const { participantId } = e.detail;
+                dispatch({ type: "PARTICIPANT_LEFT", payload: { participantId } });
+            }),
+            createEventListener("participant_metadata_changed", (e) => {
+                const { participantId, displayName } = e.detail;
+                dispatch({ type: "PARTICIPANT_METADATA_CHANGED", payload: { participantId, displayName } });
+            }),
+            createEventListener("participant_stream_added", (e) => {
+                const { participantId, stream } = e.detail;
+                dispatch({ type: "PARTICIPANT_STREAM_ADDED", payload: { participantId, stream } });
+            }),
+            createEventListener("participant_video_enabled", (e) => {
+                const { participantId, isVideoEnabled } = e.detail;
+                dispatch({ type: "PARTICIPANT_VIDEO_ENABLED", payload: { participantId, isVideoEnabled } });
+            }),
+            createEventListener("room_connection_status_changed", (e) => {
+                const { roomConnectionStatus } = e.detail;
+                dispatch({
+                    type: "ROOM_CONNECTION_STATUS_CHANGED",
+                    payload: { roomConnectionStatus },
+                });
+            }),
+            createEventListener("room_joined", (e) => {
+                const { localParticipant, remoteParticipants, waitingParticipants } = e.detail;
+                dispatch({
+                    type: "ROOM_JOINED",
+                    payload: { localParticipant, remoteParticipants, waitingParticipants },
+                });
+            }),
+            createEventListener("screenshare_started", (e) => {
+                const { participantId, stream, id, hasAudioTrack } = e.detail;
+                dispatch({
+                    type: "SCREENSHARE_STARTED",
+                    payload: { participantId, stream, id, hasAudioTrack },
+                });
+            }),
+            createEventListener("screenshare_stopped", (e) => {
+                const { participantId, id } = e.detail;
+                dispatch({
+                    type: "SCREENSHARE_STOPPED",
+                    payload: { participantId, id },
+                });
+            }),
+            createEventListener("streaming_started", (e) => {
+                const { status, startedAt } = e.detail;
+                dispatch({ type: "STREAMING_STARTED", payload: { status, startedAt } });
+            }),
+            createEventListener("streaming_stopped", () => {
+                dispatch({ type: "STREAMING_STOPPED" });
+            }),
+            createEventListener("waiting_participant_joined", (e) => {
+                const { participantId, displayName } = e.detail;
+                dispatch({
+                    type: "WAITING_PARTICIPANT_JOINED",
+                    payload: { participantId, displayName },
+                });
+            }),
+        ],
         []
     );
 


### PR DESCRIPTION
Define event listeners in an array and add them via a loop instead of adding them one by one. This makes it easy to remove these listeners in the hook cleanup when the component unmounts.

### Test plan

1. Wrap your sdk test app with `<React.StrictMode>` => only one event listener should be added for each event. You can use the Chrome DevTool's `getEventListeners` util fn to see this.
2. Knock, Join a room, share screen, start recording, reload signaling server => everything should work as before.

### Screenshots

Opening my test app with strict mode and inspecting the RoomConnection's evt listeners:

| before | after |
| --- | --- |
| <img width="380" alt="Screenshot 2023-09-08 at 11 08 31" src="https://github.com/whereby/browser-sdk/assets/1159931/4127fee1-02bd-491f-bc1f-91dde7879b63"> | <img width="332" alt="Screenshot 2023-09-08 at 11 10 30" src="https://github.com/whereby/browser-sdk/assets/1159931/c044e4f8-ab1a-412b-ae66-7e387b0629b7"> |
