### PR TITLE
Local screenshare support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha19",
+    "version": "2.0.0-alpha20",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/LocalMedia.ts
+++ b/src/lib/LocalMedia.ts
@@ -45,12 +45,14 @@ export default class LocalMedia extends TypedLocalMediaEventTarget {
     private _constraints: MediaStreamConstraints;
     public _rtcManagers: RtcManager[];
     public stream: MediaStream;
+    public screenshareStream?: MediaStream;
 
     constructor(constraints: MediaStreamConstraints) {
         super();
         this._constraints = constraints;
         this.stream = new MediaStream();
         this._rtcManagers = [];
+        this.screenshareStream = undefined;
 
         navigator.mediaDevices.addEventListener("devicechange", this._updateDeviceList.bind(this));
     }
@@ -101,6 +103,20 @@ export default class LocalMedia extends TypedLocalMediaEventTarget {
         audioTrack.enabled = newValue;
 
         this.dispatchEvent(new CustomEvent("microphone_enabled", { detail: { enabled: newValue } }));
+    }
+
+    async startScreenshare() {
+        if (this.screenshareStream) {
+            return this.screenshareStream;
+        }
+        const screenshareStream = await navigator.mediaDevices.getDisplayMedia();
+        this.screenshareStream = screenshareStream;
+        return this.screenshareStream;
+    }
+
+    stopScreenshare() {
+        this.screenshareStream?.getTracks().forEach((track) => track.stop());
+        this.screenshareStream = undefined;
     }
 
     async setCameraDevice(deviceId: string) {

--- a/src/lib/RoomParticipant.ts
+++ b/src/lib/RoomParticipant.ts
@@ -97,11 +97,13 @@ export class Screenshare {
     public readonly id: string;
     public readonly hasAudioTrack: boolean;
     public readonly stream?: MediaStream;
+    public readonly isLocal: boolean = false;
 
-    constructor({ participantId, id, hasAudioTrack, stream }: Screenshare) {
+    constructor({ participantId, id, hasAudioTrack, stream, isLocal }: Screenshare) {
         this.participantId = participantId;
         this.id = id;
         this.hasAudioTrack = hasAudioTrack;
         this.stream = stream;
+        this.isLocal = isLocal;
     }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -76,6 +76,7 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManager" {
         disconnect(streamId: string, activeBreakout: boolean): void;
         disconnectAll(): void;
         replaceTrack(oldTrack: MediaStreamTrack, newTrack: MediaStreamTrack): Promise<void>;
+        removeStream(streamId: string, _stream: MediaStream, requestedByClientId: string | null): void;
         shouldAcceptStreamsFromBothSides?: () => boolean;
         updateStreamResolution(streamId: string, ignored: null, resolution: { width: number; height: number }): void;
     }


### PR DESCRIPTION
Adds support for starting/stopping local screenshare.
This is done in the room connection hook - not the local media hook.
The local screenshare will be added to the array of screenshares, but it will have a `isLocal: true` prop, so it's easy to filter on your own screenshare. 

Minimal example of usage:
```js
const { actions } = useRoomConnection(...);

const { startScreenshare, stopScreenshare } = actions;

return (
  <button onClick={() => startScreenshare()}>Start Screen Share</button>
  <button onClick={() => stopScreenshare()}>Stop Screen Share</button>
);
```
