### PR TITLE
Add missing events dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "assert": "^2.0.0",
         "axios": "^1.2.3",
         "btoa": "^1.2.1",
+        "events": "^3.3.0",
         "heresy": "^1.0.4"
     },
     "peerDependencies": {


### PR DESCRIPTION
The `events` lib is used in `src/lib/api/credentialsService/index.ts` but it's not in the dependency list. It was already installed as an other pkg's dep, but it's safer to have it in the main package.json as well.