### PR TITLE
Do not resolve `assert` in rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha20",
+    "version": "2.0.0-alpha21",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,7 @@ function makeCdnFilename() {
 
 const plugins = [
     replace(replaceValues),
-    nodeResolve({ preferBuiltins: false, resolveOnly: [/jslib-media|assert|util/] }),
+    nodeResolve({ preferBuiltins: false, resolveOnly: [/jslib-media|util/] }),
     commonjs(),
     typescript(),
 ];


### PR DESCRIPTION
This currently breaks the apps that use the Browser SDK as it relies on another unresolved dep. Removing it from the `nodeResolve` fn makes the test React apps work with the SDK again.

However Vite apps are going to break. But they're broken without this change too. An easy solution on the vite app side is to add the process to the config (https://github.com/vitejs/vite/issues/1973#issuecomment-820343918) like this:

```js
export default defineConfig({
  // ...
  define: {
    'process.env': process.env
  }
})
```

Related PR: https://github.com/whereby/browser-sdk/pull/60