### PR TITLE
add toggle chat command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",

--- a/src/lib/__tests__/index.unit.js
+++ b/src/lib/__tests__/index.unit.js
@@ -76,6 +76,7 @@ describe("@whereby/browser-sdk", () => {
                     toggleCamera: expect.any(Function),
                     toggleMicrophone: expect.any(Function),
                     toggleScreenshare: expect.any(Function),
+                    toggleChat: expect.any(Function),
                 })
             );
         });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -94,6 +94,9 @@ define("WherebyEmbed", {
     toggleScreenshare(enabled) {
         this._postCommand("toggle_screenshare", [enabled]);
     },
+    toggleChat(enabled) {
+        this._postCommand("toggle_chat", [enabled]);
+    },
 
     onmessage({ origin, data }) {
         if (origin !== this.roomUrl.origin) return;


### PR DESCRIPTION
Allows chat toggle commands to be sent to the embedded element

For more info: https://github.com/whereby/pwa/pull/3763
https://linear.app/whereby/issue/PAN-305/add-chat-open-and-close-methods-to-embed-element#comment-4820984f