### PR TITLE
what if we incremental build in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,18 @@
     },
     "browserslist": "> 0.5%, last 2 versions, not dead",
     "source": "src/index.js",
-    "main": "dist/lib.cjs",
-    "module": "dist/lib.esm.js",
+    "main": "dist/lib/index.js",
+    "module": "dist/lib/index.js",
     "type": "module",
     "files": [
         "dist/**/*.js",
         "dist/*.d.ts"
     ],
-    "types": "dist/types.d.ts",
+    "types": "dist/index.d.d.ts",
     "scripts": {
         "prebuild": "rimraf dist",
         "build": "rollup -c",
+        "build:dev": "rollup --watch --config rollup.config.dev.js",
         "build:storybook": "build-storybook",
         "dev": "start-storybook -p 6006",
         "test": "yarn test:lint && yarn test:unit",
@@ -33,6 +34,7 @@
     "devDependencies": {
         "@babel/core": "^7.18.5",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+        "@mprt/rollup-plugin-incremental": "^0.1.0",
         "@rollup/plugin-commonjs": "^24.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,0 +1,40 @@
+import commonjs from "@rollup/plugin-commonjs";
+import replace from "@rollup/plugin-replace";
+import typescript from "rollup-plugin-typescript2";
+import dts from "rollup-plugin-dts";
+import incremental from "@mprt/rollup-plugin-incremental";
+import { peerDependencies, replaceValues } from "./rollup.config";
+
+const plugins = [incremental(), replace(replaceValues), commonjs(), typescript(), incremental.fixSNE()];
+
+export default [
+    {
+        input: "src/lib/index.ts",
+        treeshake: false,
+        output: {
+            exports: "named",
+            dir: "build",
+            format: "esm",
+            preserveModules: true,
+            preserveModulesRoot: "src",
+            minifyInternalExports: false,
+        },
+        external: ["heresy", ...peerDependencies],
+        plugins,
+    },
+
+    {
+        input: "./build/lib/index.d.ts",
+        treeshake: false,
+        output: [
+            {
+                dir: "build",
+                format: "es",
+                preserveModules: true,
+                preserveModulesRoot: "src",
+                minifyInternalExports: false,
+            },
+        ],
+        plugins: [dts()],
+    },
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import pkg from "./package.json";
 import typescript from "rollup-plugin-typescript2";
 import dts from "rollup-plugin-dts";
 
-const replaceValues = {
+export const replaceValues = {
     preventAssignment: true,
     values: {
         __SDK_VERSION__: pkg.version,
@@ -18,7 +18,7 @@ const replaceValues = {
     },
 };
 
-const peerDependencies = [...Object.keys(pkg.peerDependencies || {})];
+export const peerDependencies = [...Object.keys(pkg.peerDependencies || {})];
 
 function makeCdnFilename() {
     const major = pkg.version.split(".")[0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,6 +1774,11 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@mprt/rollup-plugin-incremental@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mprt/rollup-plugin-incremental/-/rollup-plugin-incremental-0.1.0.tgz#fcfe02dd2626a535d8f334285bcd76c5ccf1b17f"
+  integrity sha512-FIEYTgV0yYQc3bwDdPRiZWcTMUSKIL5CbjvI5jqj+i+OMVG6oSxlOIxidAiIkF56+5GcS78QdsKhWbnOC94M2A==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
I got annoyed with the dev experience of:
- make some changes in browser-sdk
- run build
- wait for build (admittedly only like 20s...)
- yalc push
- iterate

So instead I found an [incrememntal build addon](https://github.com/mprt-org/rollup-plugin-incremental) for rollup and had a go at adding it in.

We can point dev rollup at a separate config so that's fine, but we need to change all the packaging entries in package.json so the package is usable in whatever test project you're using. 

I thought I'd add this PR to see what people thought