### PR TITLE
Fix incorrect handling of stream added

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha21",
+    "version": "2.0.0-alpha22",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/__tests__/RoomConnection.spec.ts
+++ b/src/lib/__tests__/RoomConnection.spec.ts
@@ -1,6 +1,8 @@
 import { jest } from "@jest/globals";
 
-import RoomConnection from "../RoomConnection";
+import RoomConnection, { handleStreamAdded } from "../RoomConnection";
+import { RemoteParticipant } from "../RoomParticipant";
+import MockMediaStream from "../__mocks__/MediaStream";
 
 jest.mock("@whereby/jslib-media/src/utils/ServerSocket", () => {
     return jest.fn().mockImplementation(() => {
@@ -38,5 +40,65 @@ describe("RoomConnection", () => {
 
             expect(roomConnection.roomKey).toEqual(roomKey);
         });
+    });
+});
+
+describe("handleStreamAdded", () => {
+    let remoteParticipants: RemoteParticipant[];
+
+    beforeEach(() => {
+        remoteParticipants = [
+            new RemoteParticipant({
+                displayName: "Participant",
+                id: "id",
+                newJoiner: false,
+                streams: ["0", "screenshare"],
+                isAudioEnabled: true,
+                isVideoEnabled: true,
+            }),
+        ];
+    });
+
+    it("should return undefined if remote participant cannot be found", () => {
+        const res = handleStreamAdded(remoteParticipants, {
+            clientId: "zzz",
+            stream: new MockMediaStream(),
+            streamId: undefined,
+            streamType: undefined,
+        });
+
+        expect(res).toEqual(undefined);
+    });
+
+    it("should return `participant_stream_added` when stream id cannot be matched", () => {
+        const clientId = "id";
+        const stream = new MockMediaStream();
+        const streamId = undefined;
+
+        const res = handleStreamAdded(remoteParticipants, {
+            clientId,
+            stream,
+            streamId,
+            streamType: undefined,
+        });
+
+        expect(res?.type).toEqual("participant_stream_added");
+        expect(res?.detail).toEqual({ participantId: clientId, stream, streamId: stream.id });
+    });
+
+    it("should return `screenshare_started` when stream id is matched", () => {
+        const clientId = "id";
+        const stream = new MockMediaStream();
+        const streamId = "screenshare";
+
+        const res = handleStreamAdded(remoteParticipants, {
+            clientId,
+            stream,
+            streamId,
+            streamType: undefined,
+        });
+
+        expect(res?.type).toEqual("screenshare_started");
+        expect(res?.detail).toEqual({ participantId: clientId, stream, id: streamId, isLocal: false });
     });
 });

--- a/src/stories/components/VideoExperience.tsx
+++ b/src/stories/components/VideoExperience.tsx
@@ -23,8 +23,14 @@ export default function VideoExperience({
         logger: console,
     });
 
-    const { localParticipant, mostRecentChatMessage, remoteParticipants, roomConnectionStatus, waitingParticipants } =
-        state;
+    const {
+        localParticipant,
+        mostRecentChatMessage,
+        remoteParticipants,
+        roomConnectionStatus,
+        waitingParticipants,
+        screenshares,
+    } = state;
     const {
         knock,
         sendChatMessage,
@@ -108,6 +114,12 @@ export default function VideoExperience({
                                 ) : null}
                             </div>
                         ))}
+                        {screenshares.map(
+                            (s) =>
+                                s.stream && (
+                                    <VideoView style={{ width: 200, height: "auto" }} key={s.id} stream={s.stream} />
+                                )
+                        )}
                     </div>
                     <div className="controls">
                         <button onClick={() => toggleCamera()}>Toggle camera</button>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,8 +32,8 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManagerDispatcher" {
     interface RtcStreamAddedPayload {
         clientId: string;
         stream: MediaStream;
-        streamId: string;
-        streamType: "webcam" | "screenshare";
+        streamId: string | undefined;
+        streamType: "webcam" | "screenshare" | undefined;
     }
 
     type RtcEvents = {


### PR DESCRIPTION
The recent addition of screenshare support led to a regression in p2p rooms, where remote participant video went missing. This fixes issue #72

**Test plan**
1. `STORYBOOK_ROOM=<room_in_normal_mode> yarn dev` 
2. Verify you get video and screenshare (eg using the RoomConnectionOnly story)
3. Test the same with room in group mode