### PR TITLE
Remove handled knocker from the waiting participant list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha22",
+    "version": "2.0.0-alpha23",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -483,6 +483,13 @@ export default function useRoomConnection(
                     payload: { participantId, displayName },
                 });
             }),
+            createEventListener("waiting_participant_left", (e) => {
+                const { participantId } = e.detail;
+                dispatch({
+                    type: "WAITING_PARTICIPANT_LEFT",
+                    payload: { participantId },
+                });
+            }),
         ],
         []
     );


### PR DESCRIPTION
We accidentally removed the `waiting_participant_left` event listener during a refactor (https://github.com/whereby/browser-sdk/pull/68). This caused a bug in the knock handling: whenever a knock got accepted or rejected, it didn't get removed from the waiting participant list.

### Test plan

1. Use a locked room in your sample app
1. Join with a host who can see and accept/reject waiting participants
1. Knock the room with a guest => host should see the knocker
1. Accept the knocker => it should join the room and the waiting participant list should be empty again
