### PR TITLE
Add support for .env files locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+*.env
+*.log
+
 dist/
 node_modules/
-*.log
 storybook-static/
 yalc.lock
 .yalc/

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "babel-loader": "^8.2.5",
+        "dotenv": "^16.3.1",
+        "dotenv-run-script": "^0.4.1",
         "esbuild": "^0.19.4",
         "esbuild-plugin-replace": "^1.4.0",
         "eslint": "^8.29.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,8 @@ import { defineConfig, devices } from "@playwright/test";
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+import dotenv from "dotenv";
+dotenv.config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5837,10 +5837,28 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-expand@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
+  integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
+dotenv-run-script@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/dotenv-run-script/-/dotenv-run-script-0.4.1.tgz#918161e4344cd39e27996d71a155d1f3a06470d6"
+  integrity sha512-5mHhOVcSMY7X9lC50xjJL2oKiW75gqvpZpUmJRrFMOAdbNZ+hk8z1wIG9Rh/noEzbgRqYd34EmOpbStc1d+GOg==
+  dependencies:
+    dotenv "^16.3.1"
+    dotenv-expand "^10.0.0"
+
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 dotenv@^8.0.0:
   version "8.6.0"


### PR DESCRIPTION
Allow developers to maintain local .env files for our different settings

**Tested like** 
1. Create a `.env` file in the project root containing something like

```
REACT_APP_API_BASE_URL=<your_local_api_url>
REACT_APP_SIGNAL_BASE_URL=<your_local_signal_url>
WHEREBY_API_KEY=<your_whereby_api_key>
STORYBOOK_ROOM=<your_favourite_room>
```

2. Do `yarn dev`, verify Storybook is launched and using the provided room
3. Do `yarn test:e2e`, verify tests are run against your local environment