### PR TITLE
remove build step for npm distribution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
     preset: "ts-jest",
     testEnvironment: "jsdom",
     testMatch: ["<rootDir>/src/**/__tests__/**/*.[jt]s?(x)", "<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha24",
+    "version": "2.0.0-alpha25",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",
@@ -10,23 +10,24 @@
     },
     "browserslist": "> 0.5%, last 2 versions, not dead",
     "source": "src/index.js",
-    "module": "dist/index.esm.js",
+    "main": "./dist/index.js",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.esm.js"
+            "import": "./dist/index.js",
+            "require": "./dist/index.js"
         }
     },
-    "type": "module",
     "files": [
         "dist/**/*.js",
         "dist/**/*.d.ts"
     ],
-    "types": "dist/index.d.ts",
     "scripts": {
         "prebuild": "rimraf dist",
         "build": "node build.js",
-        "postbuild": "tsc --emitDeclarationOnly --declaration --project tsconfig.build.json",
+        "postbuild": "tsc --project tsconfig.build.json",
         "build:storybook": "build-storybook",
         "dev": "start-storybook -p 6006",
         "install:e2e-sample-app": "cd test/sample-app && yarn",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "emitDeclarationOnly": true,
+        "emitDeclarationOnly": false,
         "noEmit": false,
         "outDir": "dist",
         "removeComments": true


### PR DESCRIPTION
we can expect anyone installing from npm is using a bundler, so bundling
ourselves is redundant and causing build issues intermittently.

### Gotchas
required removing `"type": "module"` from package.json in order for some resolution to work correctly in CRA, which meant changing some imports to requires, and exports to module.exports 

Wepack/CRA also doesn't respect the `exports` key in package.json for some reason, so I've re-added the legacy main/module/types keys

### Testing

- `yalc publish` this version

#### vite/cra/next test projects
- `yalc add @whereby.com/browser-sdk@2.0.0-alpha25`
- `yarn` to install dependencies
- start up the dev server
- see the build succeeds and the app is usable
- `yarn build && npx serve ./{dist|build}`
- see the build succeeds and the app is usable

#### CDN distribution
- `yarn build` this lib
- copy the `v2-aplha25.js` into your test project and import it with a `<script/>` tag
- see the `whereby-embed` element works