### PR TITLE
Handle native stop screen share

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha25",
+    "version": "2.0.0-alpha26",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -901,6 +901,18 @@ export default class RoomConnection extends TypedEventTarget {
 
     public async startScreenshare() {
         const screenshareStream = this.localMedia.screenshareStream || (await this.localMedia.startScreenshare());
+        const onEnded = () => {
+            this.stopScreenshare();
+        };
+
+        if ("oninactive" in screenshareStream) {
+            // Chrome
+            screenshareStream.addEventListener("inactive", onEnded);
+        } else {
+            // FF
+            screenshareStream.getVideoTracks()[0]?.addEventListener("ended", onEnded);
+        }
+
         this.rtcManager?.addNewStream(screenshareStream.id, screenshareStream, false, true);
         this.screenshares = [
             ...this.screenshares,


### PR DESCRIPTION
Browsers have a native notification to "Stop screen share". Clicking it stops the screen share, but it stays still in the state.

Adding a listener to catch streams' ends should help fix this issue.

### Test plan

1. Open your sdk sample app with 2 clients
2. Start a screen share with one of them => it should be visible for both clients
3. Click the browser notification's "stop" button => screen share should stop for both clients properly (without black or frozen frames)
4. Test it in Chrome, FF, Safari