### PR TITLE
Add externalId as attribute in RoomConnectionOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha25",
+    "version": "2.0.0-alpha26",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -43,6 +43,7 @@ export interface RoomConnectionOptions {
     roomKey?: string;
     logger?: Logger;
     localMedia?: LocalMedia;
+    externalId?: string;
 }
 
 export type ChatMessage = Pick<SignalChatMessage, "senderId" | "timestamp" | "text">;
@@ -260,11 +261,12 @@ export default class RoomConnection extends TypedEventTarget {
     private logger: Logger;
     private _ownsLocalMedia = false;
     private displayName?: string;
+    private externalId?: string;
     private _roomKey: string | null;
 
     constructor(
         roomUrl: string,
-        { displayName, localMedia, localMediaConstraints, logger, roomKey }: RoomConnectionOptions
+        { displayName, localMedia, localMediaConstraints, logger, roomKey, externalId }: RoomConnectionOptions
     ) {
         super();
         this.organizationId = "";
@@ -281,6 +283,7 @@ export default class RoomConnection extends TypedEventTarget {
             warn: noop,
         };
         this.displayName = displayName;
+        this.externalId = externalId;
         this.localMediaConstraints = localMediaConstraints;
         const urls = fromLocation({ host: this.roomUrl.host });
 
@@ -769,6 +772,7 @@ export default class RoomConnection extends TypedEventTarget {
             roomName: this.roomName,
             selfId: "",
             userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
+            externalId: this.externalId,
         });
     }
 
@@ -778,7 +782,6 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
 
-        this.logger.log("Joining room");
         this.signalSocket.connect();
         this.roomConnectionStatus = "connecting";
         this.dispatchEvent(
@@ -828,6 +831,7 @@ export default class RoomConnection extends TypedEventTarget {
             organizationId: this.organizationId,
             roomKey: this._roomKey,
             roomName: this.roomName,
+            externalId: this.externalId,
         });
     }
 

--- a/src/lib/__tests__/embed.spec.ts
+++ b/src/lib/__tests__/embed.spec.ts
@@ -30,6 +30,7 @@ describe("@whereby/browser-sdk", () => {
                         "groups",
                         "virtualbackgroundurl",
                         "avatarurl",
+                        "externalid",
                         "audio",
                         "background",
                         "cameraaccess",

--- a/src/lib/embed/index.ts
+++ b/src/lib/embed/index.ts
@@ -8,6 +8,7 @@ interface WherebyEmbedAttributes {
     chat: string;
     displayName: string;
     emptyRoomInvitation: string;
+    externalId: string;
     floatSelf: string;
     help: string;
     leaveButton: string;
@@ -76,6 +77,7 @@ define("WherebyEmbed", {
         "groups",
         "virtualBackgroundUrl",
         "avatarUrl",
+        "externalId",
         ...boolAttrs,
     ].map((a) => a.toLowerCase()),
     onattributechanged({ attributeName, oldValue }: { attributeName: string; oldValue: string | boolean }) {
@@ -125,6 +127,7 @@ define("WherebyEmbed", {
         const {
             avatarurl: avatarUrl,
             displayname: displayName,
+            externalId: externalId,
             lang,
             metadata,
             minimal,
@@ -153,6 +156,7 @@ define("WherebyEmbed", {
             ...(displayName && { displayName }),
             ...(lang && { lang }),
             ...(metadata && { metadata }),
+            ...(externalId && { externalId }),
             ...(groups && { groups }),
             ...(virtualBackgroundUrl && { virtualBackgroundUrl }),
             ...(avatarUrl && { avatarUrl }),

--- a/src/stories/prebuilt-ui.stories.tsx
+++ b/src/stories/prebuilt-ui.stories.tsx
@@ -10,6 +10,7 @@ interface WherebyEmbedAttributes {
     chat: boolean;
     displayName: string;
     emptyRoomInvitation: string;
+    externalId: string;
     floatSelf: boolean;
     help: boolean;
     leaveButton: boolean;
@@ -34,6 +35,7 @@ export default {
         displayName: { control: "text", description: "The name to use for the local participant" },
         embed: { control: "boolean" },
         emptyRoomInvitation: { control: "boolean" },
+        externalId: { control: "text", description: "An external id to use for the local participant" },
         floatSelf: { control: "boolean" },
         help: { control: "boolean" },
         leaveButton: { control: "boolean" },
@@ -60,6 +62,7 @@ const WherebyEmbed = ({
     chat,
     displayName,
     emptyRoomInvitation,
+    externalId,
     floatSelf,
     help,
     leaveButton,
@@ -82,6 +85,7 @@ const WherebyEmbed = ({
                 chat={offOn(chat)}
                 displayName={displayName}
                 emptyRoomInvitation={emptyRoomInvitation}
+                externalId={externalId}
                 floatSelf={offOn(floatSelf)}
                 help={offOn(help)}
                 leaveButton={offOn(leaveButton)}
@@ -110,6 +114,7 @@ WherebyEmbedElement.args = {
     chat: true,
     displayName: "Your name",
     emptyRoomInvitation: "true",
+    externalId: null,
     floatSelf: false,
     help: true,
     leaveButton: true,


### PR DESCRIPTION
https://linear.app/whereby/issue/KOA-454/add-externalid-as-an-attribute-for-the-browser-sdk

Related to recent merge in stable release: https://github.com/whereby/browser-sdk/pull/89

Adds externalId to embed element and via RoomConnectionOptions.

## Test plan
* Run SDK in a demo-app
* Add `externalId` to options in `useRoomConnection` hook
eg.

``` const roomConnection = useRoomConnection(ROOM_URL, {
    displayName: "james",
    localMediaConstraints: {
      video: true,
      audio: false,
    },
    logger: console,
    externalId: "jimbob-external-id",
  });
```
* Verify externalId is passed through to signal messages.


## Screenshots

<img width="1242" alt="Screenshot 2023-10-19 at 16 37 46" src="https://github.com/whereby/browser-sdk/assets/117101145/777306da-a338-4055-b9f0-0e4536009bd6">
