### PR TITLE
Add mirror support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha27",
+    "version": "2.0.0-alpha26",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/react/VideoView.tsx
+++ b/src/lib/react/VideoView.tsx
@@ -4,6 +4,7 @@ import debounce from "../utils/debounce";
 interface VideoViewSelfProps {
     stream: MediaStream;
     muted?: boolean;
+    mirror?: boolean;
     style?: React.CSSProperties;
     onResize?: ({ width, height, stream }: { width: number; height: number; stream: MediaStream }) => void;
 }
@@ -11,7 +12,7 @@ interface VideoViewSelfProps {
 type VideoViewProps = VideoViewSelfProps &
     React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
 
-export default ({ muted, stream, onResize, ...rest }: VideoViewProps) => {
+export default ({ muted, mirror = false, stream, onResize, ...rest }: VideoViewProps) => {
     const videoEl = useRef<HTMLVideoElement>(null);
 
     useEffect(() => {
@@ -57,5 +58,13 @@ export default ({ muted, stream, onResize, ...rest }: VideoViewProps) => {
         }
     }, [muted, stream, videoEl]);
 
-    return <video ref={videoEl} autoPlay playsInline {...rest} />;
+    return (
+        <video
+            ref={videoEl}
+            autoPlay
+            playsInline
+            {...rest}
+            style={{ transform: mirror ? "scaleX(-1)" : "none", ...rest.style }}
+        />
+    );
 };


### PR DESCRIPTION
Adds a `mirror: boolean` prop on the `VideoView` component to allow for easy mirroring of the video.

### Test plan

1. Open your sdk sample app
2. Add `mirror` prop to the `VideoView`
3. Verify that the video is mirrored
4. Verify that the `style` prop still works