### PR TITLE
Improve e2e tests' performance

### DIFF
--- a/test/testsuites/connect.spec.ts
+++ b/test/testsuites/connect.spec.ts
@@ -5,14 +5,14 @@ test.describe("unlocked room", () => {
     let meetingId: string;
     let roomUrl: string;
 
-    test.beforeEach(async () => {
+    test.beforeAll(async () => {
         ({ meetingId, roomUrl } = await createTransientRoom({
             isLocked: false,
             roomMode: "normal",
         }));
     });
 
-    test.afterEach(async () => {
+    test.afterAll(async () => {
         await deleteTransientRoom(meetingId);
     });
 

--- a/test/testsuites/mediaToggles.spec.ts
+++ b/test/testsuites/mediaToggles.spec.ts
@@ -8,14 +8,14 @@ roomModes.forEach((roomMode) => {
         let meetingId: string;
         let roomUrl: string;
 
-        test.beforeEach(async () => {
+        test.beforeAll(async () => {
             ({ meetingId, roomUrl } = await createTransientRoom({
                 isLocked: false,
                 roomMode,
             }));
         });
 
-        test.afterEach(async () => {
+        test.afterAll(async () => {
             await deleteTransientRoom(meetingId);
         });
 

--- a/test/testsuites/screenshare.spec.ts
+++ b/test/testsuites/screenshare.spec.ts
@@ -8,14 +8,14 @@ roomModes.forEach((roomMode) => {
         let meetingId: string;
         let roomUrl: string;
 
-        test.beforeEach(async () => {
+        test.beforeAll(async () => {
             ({ meetingId, roomUrl } = await createTransientRoom({
                 isLocked: false,
                 roomMode,
             }));
         });
 
-        test.afterEach(async () => {
+        test.afterAll(async () => {
             await deleteTransientRoom(meetingId);
         });
 

--- a/test/testsuites/video.spec.ts
+++ b/test/testsuites/video.spec.ts
@@ -14,14 +14,14 @@ roomModes.forEach((roomMode) => {
         let meetingId: string;
         let roomUrl: string;
 
-        test.beforeEach(async () => {
+        test.beforeAll(async () => {
             ({ meetingId, roomUrl } = await createTransientRoom({
                 isLocked: false,
                 roomMode,
             }));
         });
 
-        test.afterEach(async () => {
+        test.afterAll(async () => {
             await deleteTransientRoom(meetingId);
         });
 

--- a/test/testsuites/video.spec.ts
+++ b/test/testsuites/video.spec.ts
@@ -70,8 +70,8 @@ roomModes.forEach((roomMode) => {
                 .getByTestId("remoteParticipantVideo")
                 .evaluate((element: HTMLVideoElement, countFramesFn) => {
                     const countFrames = countFramesFn as CountFramesFunction;
-                    // counts 15 samples in a 1000ms interval.
-                    return countFrames(element, 1000, 15);
+                    // counts 10 samples in a 1000ms interval.
+                    return countFrames(element, 1000, 10);
                 }, countFramesHandle);
             const participant1FrameStatistics = makeFrameStatistics(participant1Samples);
 


### PR DESCRIPTION
* Decrease video e2e test frame count: only collect samples for 10 secs to make tests run a bit faster. So they should fit into the 30sec timeframe / test
* Create 1 room only per test (for each room mode). We might not need a new room for each test and it's easy to hit the api rate limit when we create/delete rooms before/after each tests. Using just 1 room per room mode per test file also works and we save a many rate limit points.

### Test plan

CI should be green.