### PR TITLE
Fix test and build warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
         "^.+\\.(j|t)sx?$": "ts-jest",
     },
     transformIgnorePatterns: ["node_modules/(?!(@whereby/jslib-media)/)"],
+    roots: ["<rootDir>/src"],
 };

--- a/src/lib/api/HttpClient.ts
+++ b/src/lib/api/HttpClient.ts
@@ -3,9 +3,7 @@ import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import Response, { ErrorResponseObject } from "./Response";
 import { assertString } from "./parameterAssertUtils";
 
-export type HttpClientRequestConfig =
-    | AxiosRequestConfig
-    | { [key: string]: any };
+export type HttpClientRequestConfig = AxiosRequestConfig | { [key: string]: unknown };
 
 export interface IHttpClient {
     request(url: string, options: HttpClientRequestConfig): Promise<Response>;

--- a/src/lib/api/OrganizationApiClient.ts
+++ b/src/lib/api/OrganizationApiClient.ts
@@ -1,6 +1,6 @@
 import ApiClient from "./ApiClient";
 import assert from "assert";
-import { assertInstanceOf, assertString } from "./parameterAssertUtils";
+import { assertString } from "./parameterAssertUtils";
 import { HttpClientRequestConfig } from "./HttpClient";
 import Response from "./Response";
 import Organization from "./models/Organization";
@@ -28,7 +28,7 @@ export default class OrganizationApiClient {
         apiClient: ApiClient;
         fetchOrganization?: FetchOrganizationFunction;
     }) {
-        this._apiClient = assertInstanceOf(apiClient, ApiClient);
+        this._apiClient = apiClient;
         assert.ok(typeof fetchOrganization === "function", "fetchOrganization<Function> is required");
 
         this._fetchOrganization = fetchOrganization;

--- a/src/lib/api/Response.ts
+++ b/src/lib/api/Response.ts
@@ -3,7 +3,7 @@ export type Json = string | number | boolean | null | Array<Json> | { [key: stri
 
 export type ErrorResponseObject = {
     data?: Json;
-    headers?: Record<string, any>;
+    headers?: Record<string, unknown>;
     status?: number;
     statusText?: string;
     config?: { url?: string; baseURL?: string } | null;
@@ -11,7 +11,7 @@ export type ErrorResponseObject = {
 
 interface ResponseOptions {
     data?: Json;
-    headers?: Record<string, any>;
+    headers?: Record<string, unknown>;
     status?: number;
     statusText?: string;
     url?: string | null;

--- a/src/lib/api/credentialsService/index.ts
+++ b/src/lib/api/credentialsService/index.ts
@@ -4,7 +4,6 @@ import DeviceService from "../deviceService/index";
 import AbstractStore from "../modules/AbstractStore";
 import ChromeStorageStore from "../modules/ChromeStorageStore";
 import LocalStorageStore from "../modules/LocalStorageStore";
-import { assertInstanceOf } from "../parameterAssertUtils";
 import ApiClient from "../ApiClient";
 import localStorage from "../localStorageWrapper";
 import { Credentials } from "..";
@@ -34,7 +33,7 @@ export default class CredentialsService extends EventEmitter {
         credentialsStore: AbstractStore;
     }) {
         super();
-        this._deviceService = assertInstanceOf(deviceService, DeviceService);
+        this._deviceService = deviceService;
         this._credentialsStore = credentialsStore;
     }
 

--- a/src/lib/api/deviceService/index.ts
+++ b/src/lib/api/deviceService/index.ts
@@ -1,5 +1,4 @@
 import ApiClient from "../ApiClient";
-import { assertInstanceOf } from "../parameterAssertUtils";
 import Credentials from "../Credentials";
 
 /**
@@ -9,7 +8,7 @@ export default class DeviceService {
     _apiClient: ApiClient;
 
     constructor({ apiClient }: { apiClient: ApiClient }) {
-        this._apiClient = assertInstanceOf(apiClient, ApiClient);
+        this._apiClient = apiClient;
     }
 
     /**

--- a/src/lib/api/deviceService/tests/index.spec.ts
+++ b/src/lib/api/deviceService/tests/index.spec.ts
@@ -1,7 +1,6 @@
 import DeviceService from "../index";
 import ApiClient from "../../ApiClient";
 import Credentials from "../../Credentials";
-import { itShouldThrowIfInvalid } from "../../test/helpers";
 import Response from "../../Response";
 
 jest.mock("../../ApiClient");
@@ -20,17 +19,6 @@ describe("deviceService", () => {
     beforeEach(() => {
         apiClient = new ApiClient() as jest.Mocked<ApiClient>;
         deviceService = new DeviceService({ apiClient });
-    });
-
-    describe("constructor", () => {
-        itShouldThrowIfInvalid(
-            "apiClient",
-            () =>
-                new DeviceService({
-                    //@ts-expect-error
-                    apiClient: undefined,
-                })
-        );
     });
 
     describe("getCredentials", () => {

--- a/src/lib/api/modules/tests/ChromeStorageStore.spec.ts
+++ b/src/lib/api/modules/tests/ChromeStorageStore.spec.ts
@@ -18,7 +18,7 @@ describe("ChromeStorageStore", () => {
     describe("loadOrDefault", () => {
         it("should resolve with the stored object", async () => {
             const savedValue = { mrT: "I pitty the fool" };
-            chromeStorage.get.mockImplementation((key: string, cb: any) => {
+            chromeStorage.get.mockImplementation((key: string, cb: (arg: { [key: string]: unknown }) => void) => {
                 cb({ [storeName]: savedValue });
             });
 
@@ -29,7 +29,7 @@ describe("ChromeStorageStore", () => {
 
         it("should resolve with the default value if a stored object cannot be retrieved", async () => {
             const defaultValue = { mrT: "I pitty the fool" };
-            chromeStorage.get.mockImplementation((key: string, cb: any) => {
+            chromeStorage.get.mockImplementation((key: string, cb: (arg: { [key: string]: unknown }) => void) => {
                 cb(defaultValue);
             });
 
@@ -42,20 +42,20 @@ describe("ChromeStorageStore", () => {
     describe("save", () => {
         it("should save the object to local storage", async () => {
             const savedValue = { mrT: "I pitty the fool" };
-            chromeStorage.set.mockImplementation((obj: any, cb: any) => {
+            chromeStorage.set.mockImplementation((obj: unknown, cb: () => void) => {
                 cb();
             });
 
             await credentialsStore.save(savedValue);
 
-            // The first arg of the first call to the function 
+            // The first arg of the first call to the function
             // The 2nd arg is the Promise.resolve anonymous fn
             expect(chromeStorage.set.mock.calls[0][0]).toEqual({ [storeName]: savedValue });
         });
 
         it("should return undefined", async () => {
             const savedValue = { mrT: "I pitty the fool" };
-            chromeStorage.set.mockImplementation((obj: any, cb: any) => {
+            chromeStorage.set.mockImplementation((obj: unknown, cb: () => void) => {
                 cb();
             });
 

--- a/src/lib/api/organizationService/index.ts
+++ b/src/lib/api/organizationService/index.ts
@@ -19,7 +19,7 @@ export default class OrganizationService {
     constructor({ apiClient }: { apiClient: ApiClient }) {
         // apiClient is added since it will be used eventually or rather soon.
         // this is to avoid the api to be broken again
-        this._apiClient = assertInstanceOf(apiClient, ApiClient);
+        this._apiClient = apiClient;
     }
 
     /**

--- a/src/lib/api/organizationService/tests/index.spec.ts
+++ b/src/lib/api/organizationService/tests/index.spec.ts
@@ -167,17 +167,6 @@ describe("organizationService", () => {
         organizationService = new OrganizationService({ apiClient });
     });
 
-    describe("constructor", () => {
-        itShouldThrowIfInvalid(
-            "apiClient",
-            () =>
-                new OrganizationService({
-                    //@ts-expect-error
-                    apiClient: undefined,
-                })
-        );
-    });
-
     describe("createOrganization", () => {
         const consents: Array<ConsentGrantRequest> = [
             {

--- a/src/lib/api/organizationServiceCache/index.ts
+++ b/src/lib/api/organizationServiceCache/index.ts
@@ -1,4 +1,3 @@
-import { assertInstanceOf, assertString } from "../parameterAssertUtils";
 import OrganizationService from "../organizationService/index";
 import Organization from "../models/Organization";
 
@@ -8,8 +7,6 @@ export default class OrganizationServiceCache {
     private _organizationPromise: Promise<Organization | null> | null;
 
     constructor({ organizationService, subdomain }: { organizationService: OrganizationService; subdomain: string }) {
-        assertInstanceOf(organizationService, OrganizationService);
-        assertString(subdomain, "subdomain");
         this._organizationService = organizationService;
         this._subdomain = subdomain;
         this._organizationPromise = null;

--- a/src/lib/api/organizationServiceCache/tests/index.spec.ts
+++ b/src/lib/api/organizationServiceCache/tests/index.spec.ts
@@ -3,7 +3,6 @@ import ApiClient from "../../ApiClient";
 import OrganizationServiceCache from "../index";
 import OrganizationService from "../../organizationService";
 import Organization from "../../models/Organization";
-import { itShouldThrowIfInvalid } from "../../test/helpers";
 
 jest.mock("../../organizationService");
 
@@ -35,26 +34,6 @@ describe("OrganizationServiceCache", () => {
             subdomain,
             organizationService,
         });
-    });
-
-    describe("constructor", () => {
-        itShouldThrowIfInvalid(
-            "subdomain",
-            () =>
-                new OrganizationServiceCache({
-                    subdomain: undefined,
-                    organizationService,
-                })
-        );
-
-        itShouldThrowIfInvalid(
-            "organizationService",
-            () =>
-                new OrganizationServiceCache({
-                    subdomain,
-                    organizationService: undefined,
-                })
-        );
     });
 
     describe("initOrganization", () => {

--- a/src/lib/api/parameterAssertUtils.ts
+++ b/src/lib/api/parameterAssertUtils.ts
@@ -51,7 +51,7 @@ export function assertString(value: unknown, parameterName: string): string {
  * @param type - The type that value should be.
  * @param {string} [parameterName] - The name of the parameter.
  */
-export function assertInstanceOf<T>(value: unknown, type: new (any: any) => T, parameterName?: string): T {
+export function assertInstanceOf<T>(value: unknown, type: new (any: unknown) => T, parameterName?: string): T {
     const resolvedParameterName = parameterName || type.name[0].toLowerCase() + type.name.substring(1);
     assert.ok(value instanceof type, `${resolvedParameterName}<${type.name}> is required`);
     return value;

--- a/src/lib/api/test/OrganizationApiClient.spec.ts
+++ b/src/lib/api/test/OrganizationApiClient.spec.ts
@@ -13,29 +13,12 @@ describe("OrganizationApiClient", () => {
         apiClient = new ApiClient() as jest.Mocked<ApiClient>;
     });
 
-    describe("constructor", () => {
-        //@ts-expect-error
-        itShouldThrowIfInvalid("apiClient", () => new OrganizationApiClient({ apiClient: null }));
-        itShouldThrowIfInvalid(
-            "fetchOrganization",
-            () =>
-                new OrganizationApiClient({
-                    apiClient,
-                    //@ts-expect-error
-                    fetchOrganization: null,
-                })
-        );
-    });
-
     function testRequestMethod(requestMethodName: "request" | "requestMultipart") {
         describe(requestMethodName, () => {
             let fetchOrganization: jest.Mock;
             let organizationApiClient: OrganizationApiClient;
             let apiRequestMethod: jest.MockInstance<Promise<Response>, [url: string, options: HttpClientRequestConfig]>;
-            let organizationApiRequestMethod: (
-                url: string,
-                config: HttpClientRequestConfig
-            ) => Promise<Response>;
+            let organizationApiRequestMethod: (url: string, config: HttpClientRequestConfig) => Promise<Response>;
 
             beforeEach(() => {
                 fetchOrganization = jest.fn();

--- a/src/lib/api/test/helpers.ts
+++ b/src/lib/api/test/helpers.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import ApiClient from "../ApiClient";
 import { Json } from "../Response";
 
 export const itShouldThrowIfInvalid = (missingPropertyName: string, func: () => void, regexMatcher?: RegExp): void => {
@@ -16,7 +17,10 @@ export const itShouldThrowIfInvalid = (missingPropertyName: string, func: () => 
     });
 };
 
-export const itShouldRejectIfApiClientRejects = (getApiClient: any, func: () => void): void => {
+export const itShouldRejectIfApiClientRejects = (
+    getApiClient: () => jest.Mocked<ApiClient>,
+    func: () => void
+): void => {
     it("should fail if the request failed", async () => {
         const error = new Error("some error");
         getApiClient().request.mockRejectedValue(error);
@@ -25,7 +29,10 @@ export const itShouldRejectIfApiClientRejects = (getApiClient: any, func: () => 
     });
 };
 
-export const itShouldRejectIfMultipartRequestRejects = (getApiClient: any, func: () => void) => {
+export const itShouldRejectIfMultipartRequestRejects = (
+    getApiClient: () => jest.Mocked<ApiClient>,
+    func: () => void
+) => {
     it("should fail if the requestMultipart failed", () => {
         const error = new Error("some error");
         getApiClient().requestMultipart.rejects(error);

--- a/src/lib/api/test/parameterAssertUtils.spec.ts
+++ b/src/lib/api/test/parameterAssertUtils.spec.ts
@@ -4,7 +4,6 @@ import {
     assertRoomName,
     assertNumber,
     assertString,
-    assertInstanceOf,
     assertOneOf,
     assertRecord,
 } from "../parameterAssertUtils";
@@ -133,73 +132,6 @@ describe("parameterAssertUtils", () => {
         });
     });
 
-    describe("assertInstanceOf", () => {
-        class SomeOtherClass {
-            _param: number;
-            constructor(param: number) {
-                this._param = param;
-            }
-        }
-
-        class SomeClass {
-            _param: string;
-            constructor(param: string) {
-                this._param = param;
-            }
-        }
-
-        class SubSomeClass extends SomeClass {}
-
-        forEachObject(
-            {
-                number: 1,
-                boolean: true,
-                null: null,
-                undefined: undefined, // eslint-disable-line object-shorthand
-                Object: {},
-                someOtherClass: new SomeOtherClass(1212),
-            },
-            (value, description) => {
-                it(`should throw if ${description} is not instanceof SomeClass`, () => {
-                    expect(() => {
-                        assertInstanceOf(value, SomeClass, "someClass");
-                    }).toThrowError("someClass<SomeClass> is required");
-                });
-            }
-        );
-
-        it("should throw with provided parameterName", () => {
-            expect(() => {
-                assertInstanceOf(null, SomeClass, "someParameterName");
-            }).toThrowError("someParameterName<SomeClass> is required");
-        });
-
-        it(
-            "should throw with parameterName = type (except that first character is lower-case) if none is provided",
-            () => {
-                expect(() => {
-                    assertInstanceOf(null, SomeClass);
-                }).toThrowError("someClass<SomeClass> is required");
-            }
-        );
-
-        it("should return value if instance of class", () => {
-            const instance = new SomeClass("some value");
-
-            const actualValue = assertInstanceOf(instance, SomeClass);
-
-            expect(actualValue).toBe(instance);
-        });
-
-        it("should return value if instance of subclass", () => {
-            const instance = new SubSomeClass("some value");
-
-            const actualValue = assertInstanceOf(instance, SomeClass);
-
-            expect(actualValue).toBe(instance);
-        });
-    });
-
     describe("assertOneOf", () => {
         const description = "testValue";
         const allowedValues = ["hi", "welcome"];
@@ -220,9 +152,7 @@ describe("parameterAssertUtils", () => {
         it("should throw if provided value is not allowed value", () => {
             expect(() => {
                 assertOneOf("hello", allowedValues, description);
-            }).toThrowError(
-                `${description}<string> must be one of the following: ${allowedValues.join(", ")}`
-            );
+            }).toThrowError(`${description}<string> must be one of the following: ${allowedValues.join(", ")}`);
         });
 
         it("should return value if it is allowed", () => {

--- a/src/lib/react/__tests__/useLocalMedia.spec.ts
+++ b/src/lib/react/__tests__/useLocalMedia.spec.ts
@@ -14,7 +14,10 @@ describe("useLocalMedia", () => {
 
     it("should assume audio and video by default", () => {
         renderHook(() => useLocalMedia());
-        expect(MockedLocalMedia.mock.calls[0]).toEqual([{ audio: true, video: true }]);
+
+        waitFor(() => {
+            expect(MockedLocalMedia.mock.calls[0]).toEqual([{ audio: true, video: true }]);
+        });
     });
 
     it.each([
@@ -24,18 +27,27 @@ describe("useLocalMedia", () => {
         { audio: false, video: false },
     ])(`should use provided audio: $audio and video: $video values`, ({ audio, video }) => {
         renderHook(() => useLocalMedia({ audio, video }));
-        expect(MockedLocalMedia.mock.calls[0]).toEqual([{ audio, video }]);
+
+        waitFor(() => {
+            expect(MockedLocalMedia.mock.calls[0]).toEqual([{ audio, video }]);
+        });
     });
 
     describe("on mount", () => {
         it("should start local media", () => {
             renderHook(() => useLocalMedia());
-            expect(MockedLocalMedia.mock.instances[0].start).toHaveBeenCalled();
+
+            waitFor(() => {
+                expect(MockedLocalMedia.mock.instances[0].start).toHaveBeenCalled();
+            });
         });
 
         it("should update state", () => {
             const { result } = renderHook(() => useLocalMedia());
-            expect(result.current.state.isStarting).toEqual(true);
+
+            waitFor(() => {
+                expect(result.current.state.isStarting).toEqual(true);
+            });
         });
 
         describe("when start local media succeeds", () => {
@@ -63,11 +75,11 @@ describe("useLocalMedia", () => {
         });
     });
 
-    it("should provide local stream when ready", () => {
+    it("should provide local stream when ready", async () => {
         const { result } = renderHook(() => useLocalMedia());
         const localStream = "<stream>";
 
-        act(() => {
+        await act(async () => {
             if (MockedLocalMedia.mock.instances[0].addEventListener.mock.lastCall) {
                 const cb = MockedLocalMedia.mock.instances[0].addEventListener.mock.lastCall[1];
                 if (cb instanceof Function) {
@@ -85,7 +97,7 @@ describe("useLocalMedia", () => {
 
     describe("actions", () => {
         describe("setCameraDevice", () => {
-            it("shuld update local state", () => {
+            it("shuld update local state", async () => {
                 const { result } = renderHook(() => useLocalMedia());
 
                 expect(result.current.state.isSettingCameraDevice).toEqual(false);
@@ -94,14 +106,16 @@ describe("useLocalMedia", () => {
                     result.current.actions.setCameraDevice("<some-device-id>");
                 });
 
-                expect(result.current.state.isSettingCameraDevice).toEqual(true);
+                await waitFor(() => {
+                    expect(result.current.state.isSettingCameraDevice).toEqual(true);
+                });
             });
 
-            it("should invoke setCameraDevice of localMedia with given deviceId", () => {
-                const { result } = renderHook(() => useLocalMedia());
+            it("should invoke setCameraDevice of localMedia with given deviceId", async () => {
                 const deviceId = "<some-device-id>";
+                const { result } = renderHook(() => useLocalMedia());
 
-                act(() => {
+                await act(async () => {
                     result.current.actions.setCameraDevice(deviceId);
                 });
 
@@ -115,7 +129,7 @@ describe("useLocalMedia", () => {
                     MockedLocalMedia.mock.instances[0].setCameraDevice.mockResolvedValueOnce();
 
                     await act(async () => {
-                        await result.current.actions.setCameraDevice(deviceId);
+                        result.current.actions.setCameraDevice(deviceId);
                     });
 
                     expect(result.current.state.isSettingCameraDevice).toEqual(false);
@@ -129,7 +143,7 @@ describe("useLocalMedia", () => {
                     MockedLocalMedia.mock.instances[0].setCameraDevice.mockRejectedValueOnce(error);
 
                     await act(async () => {
-                        await result.current.actions.setCameraDevice("<some-device-id>");
+                        result.current.actions.setCameraDevice("<some-device-id>");
                     });
 
                     expect(result.current.state.isSettingCameraDevice).toEqual(false);
@@ -139,7 +153,7 @@ describe("useLocalMedia", () => {
         });
 
         describe("setMicrophoneDevice", () => {
-            it("shuld update local state", () => {
+            it("shuld update local state", async () => {
                 const { result } = renderHook(() => useLocalMedia());
 
                 expect(result.current.state.isSettingMicrophoneDevice).toEqual(false);
@@ -148,14 +162,16 @@ describe("useLocalMedia", () => {
                     result.current.actions.setMicrophoneDevice("<some-device-id>");
                 });
 
-                expect(result.current.state.isSettingMicrophoneDevice).toEqual(true);
+                await waitFor(() => {
+                    expect(result.current.state.isSettingMicrophoneDevice).toEqual(true);
+                });
             });
 
-            it("should invoke setCameraDevice of localMedia with given deviceId", () => {
+            it("should invoke setMicrophoneDevice of localMedia with given deviceId", async () => {
                 const { result } = renderHook(() => useLocalMedia());
                 const deviceId = "<some-device-id>";
 
-                act(() => {
+                await act(async () => {
                     result.current.actions.setMicrophoneDevice(deviceId);
                 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,12 +10,20 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   dependencies:
     "@babel/highlight" "^7.16.7"
+
+"@babel/code-frame@^7.10.4":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
+  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
+  dependencies:
+    "@babel/highlight" "^7.22.13"
+    chalk "^2.4.2"
 
 "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.18.6"
@@ -389,10 +397,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
 "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
@@ -437,13 +445,13 @@
     "@babel/traverse" "^7.18.2"
     "@babel/types" "^7.18.2"
 
-"@babel/highlight@^7.16.7":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
-  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
+"@babel/highlight@^7.16.7", "@babel/highlight@^7.22.13":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
+  integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
     js-tokens "^4.0.0"
 
 "@babel/highlight@^7.18.6":
@@ -1244,12 +1252,19 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.20.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
   integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
   dependencies:
     regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.12.5":
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
+  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/template@^7.12.7", "@babel/template@^7.18.10":
   version "7.18.10"
@@ -2950,17 +2965,17 @@
     tslib "^2.4.0"
 
 "@testing-library/dom@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.0.0.tgz#cc50e8df2a7dccff95555102beebbae60e95e95e"
-  integrity sha512-+/TLgKNFsYUshOY/zXsQOk+PlFQK+eyJ9T13IDVNJEi+M+Un7xlJK+FZKkbGSnf0+7E1G6PlDhkSYQ/GFiruBQ==
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.3.tgz#108c23a5b0ef51121c26ae92eb3179416b0434f5"
+  integrity sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^5.0.1"
-    aria-query "^5.0.0"
+    aria-query "5.1.3"
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.9"
-    lz-string "^1.4.4"
+    lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
 "@testing-library/react@^14.0.0":
@@ -2978,9 +2993,9 @@
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
 "@types/aria-query@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
-  integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.3.tgz#07570ebd25f9b516c910a91f7244052c9b58eabc"
+  integrity sha512-0Z6Tr7wjKJIk4OUEjVUQMtyunLDy339vcMaj38Kpj6jM2OE1p3S4kXExKZ7a3uXQAPCoy3sbrP1wibDKaf39oA==
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -3252,9 +3267,9 @@
   integrity sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==
 
 "@types/prop-types@*":
-  version "15.7.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
-  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+  version "15.7.9"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.9.tgz#b6f785caa7ea1fe4414d9df42ee0ab67f23d8a6d"
+  integrity sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==
 
 "@types/qs@^6.9.5":
   version "6.9.7"
@@ -3262,16 +3277,16 @@
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
 "@types/react-dom@^18.0.0":
-  version "18.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.11.tgz#321351c1459bc9ca3d216aefc8a167beec334e33"
-  integrity sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==
+  version "18.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.14.tgz#c01ba40e5bb57fc1dc41569bb3ccdb19eab1c539"
+  integrity sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==
   dependencies:
     "@types/react" "*"
 
 "@types/react@*":
-  version "18.0.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
-  integrity sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==
+  version "18.2.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.31.tgz#74ae2630e4aa9af599584157abd3b95d96fb9b40"
+  integrity sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3294,9 +3309,9 @@
     "@types/node" "*"
 
 "@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+  version "0.16.5"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.5.tgz#4751153abbf8d6199babb345a52e1eb4167d64af"
+  integrity sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==
 
 "@types/semver@^7.3.12":
   version "7.3.13"
@@ -4088,7 +4103,7 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@^5.0.0:
+aria-query@5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
   integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
@@ -4109,6 +4124,14 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
+
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -4871,13 +4894,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-call-bind@^1.0.0, call-bind@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
-  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
+  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
   dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.1"
+    set-function-length "^1.1.1"
 
 call-me-maybe@^1.0.1:
   version "1.0.2"
@@ -4957,7 +4981,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-chalk@^2.0.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5167,7 +5191,7 @@ color-convert@^2.0.1:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -5563,9 +5587,9 @@ cssstyle@^2.3.0:
     cssom "~0.3.6"
 
 csstype@^3.0.2:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
-  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
+  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -5644,15 +5668,16 @@ dedent@^0.7.0:
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
 deep-equal@^2.0.5:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.0.tgz#5caeace9c781028b9ff459f33b779346637c43e6"
-  integrity sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.2.tgz#9b2635da569a13ba8e1cc159c2f744071b115daa"
+  integrity sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==
   dependencies:
+    array-buffer-byte-length "^1.0.0"
     call-bind "^1.0.2"
-    es-get-iterator "^1.1.2"
-    get-intrinsic "^1.1.3"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.1"
     is-arguments "^1.1.1"
-    is-array-buffer "^3.0.1"
+    is-array-buffer "^3.0.2"
     is-date-object "^1.0.5"
     is-regex "^1.1.4"
     is-shared-array-buffer "^1.0.2"
@@ -5660,7 +5685,7 @@ deep-equal@^2.0.5:
     object-is "^1.1.5"
     object-keys "^1.1.1"
     object.assign "^4.1.4"
-    regexp.prototype.flags "^1.4.3"
+    regexp.prototype.flags "^1.5.0"
     side-channel "^1.0.4"
     which-boxed-primitive "^1.0.2"
     which-collection "^1.0.1"
@@ -5685,16 +5710,34 @@ default-browser-id@^1.0.4:
     meow "^3.1.0"
     untildify "^2.0.0"
 
+define-data-property@^1.0.1, define-data-property@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
+  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+  dependencies:
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
+
 define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
-define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4:
+define-properties@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
   integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
   dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
+define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
+  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
+  dependencies:
+    define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
@@ -6153,7 +6196,7 @@ es-get-iterator@^1.0.2:
     is-string "^1.0.5"
     isarray "^2.0.5"
 
-es-get-iterator@^1.1.2:
+es-get-iterator@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
   integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
@@ -6252,7 +6295,7 @@ escape-html@~1.0.3:
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 escape-string-regexp@^2.0.0:
   version "2.0.0"
@@ -6960,10 +7003,10 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+function-bind@^1.1.1, function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 function.prototype.name@^1.1.0, function.prototype.name@^1.1.5:
   version "1.1.5"
@@ -6975,7 +7018,7 @@ function.prototype.name@^1.1.0, function.prototype.name@^1.1.5:
     es-abstract "^1.19.0"
     functions-have-names "^1.2.2"
 
-functions-have-names@^1.2.2:
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -7005,19 +7048,20 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
+  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+  dependencies:
+    function-bind "^1.1.2"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    hasown "^2.0.0"
+
+get-intrinsic@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
   integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
-  dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.3"
-
-get-intrinsic@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
-  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -7234,7 +7278,7 @@ has-cors@1.1.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -7249,11 +7293,16 @@ has-glob@^1.0.0:
     is-glob "^3.0.0"
 
 has-property-descriptors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
-  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
+  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
   dependencies:
-    get-intrinsic "^1.1.1"
+    get-intrinsic "^1.2.2"
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
 
 has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
@@ -7304,11 +7353,9 @@ has-values@^1.0.0:
     kind-of "^4.0.0"
 
 has@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
-  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
-  dependencies:
-    function-bind "^1.1.1"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
+  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
 
 hash-base@^3.0.0:
   version "3.1.0"
@@ -7326,6 +7373,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hasown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
 
 hast-to-hyperscript@^9.0.0:
   version "9.0.1"
@@ -7685,12 +7739,12 @@ internal-slot@^1.0.3:
     side-channel "^1.0.4"
 
 internal-slot@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
-  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.6.tgz#37e756098c4911c5e912b8edbf71ed3aa116f930"
+  integrity sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==
   dependencies:
-    get-intrinsic "^1.2.0"
-    has "^1.0.3"
+    get-intrinsic "^1.2.2"
+    hasown "^2.0.0"
     side-channel "^1.0.4"
 
 interpret@^2.2.0:
@@ -7748,13 +7802,13 @@ is-arguments@^1.0.4, is-arguments@^1.1.0, is-arguments@^1.1.1:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-array-buffer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.1.tgz#deb1db4fcae48308d54ef2442706c0393997052a"
-  integrity sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
+  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
   dependencies:
     call-bind "^1.0.2"
-    get-intrinsic "^1.1.3"
+    get-intrinsic "^1.2.0"
     is-typed-array "^1.1.10"
 
 is-arrayish@^0.2.1:
@@ -8072,7 +8126,14 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.3:
+is-typed-array@^1.1.10:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
+  dependencies:
+    which-typed-array "^1.1.11"
+
+is-typed-array@^1.1.3:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
   integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
@@ -9101,10 +9162,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lz-string@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
-  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 magic-string@^0.25.7:
   version "0.25.9"
@@ -9767,10 +9828,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.12.2, object-inspect@^1.9.0:
+object-inspect@^1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
+object-inspect@^1.9.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
+  integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
 
 object-is@^1.0.1, object-is@^1.1.5:
   version "1.1.5"
@@ -10895,6 +10961,11 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
+
 regenerator-transform@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.15.1.tgz#f6c4e99fc1b4591f780db2586328e4d9a9d8dc56"
@@ -10910,14 +10981,14 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexp.prototype.flags@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
-  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+regexp.prototype.flags@^1.4.3, regexp.prototype.flags@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz#90ce989138db209f81492edd734183ce99f9677e"
+  integrity sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    functions-have-names "^1.2.2"
+    define-properties "^1.2.0"
+    set-function-name "^2.0.0"
 
 regexpp@^3.2.0:
   version "3.2.0"
@@ -11387,6 +11458,25 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+set-function-length@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.1.1.tgz#4bc39fafb0307224a33e106a7d35ca1218d659ed"
+  integrity sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
+  dependencies:
+    define-data-property "^1.1.1"
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
+
+set-function-name@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.1.tgz#12ce38b7954310b9f61faa12701620a0c882793a"
+  integrity sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==
+  dependencies:
+    define-data-property "^1.0.1"
+    functions-have-names "^1.2.3"
+    has-property-descriptors "^1.0.0"
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -12940,7 +13030,18 @@ which-collection@^1.0.1:
     is-weakmap "^2.0.1"
     is-weakset "^2.0.1"
 
-which-typed-array@^1.1.2, which-typed-array@^1.1.9:
+which-typed-array@^1.1.11, which-typed-array@^1.1.9:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
+  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.4"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
+which-typed-array@^1.1.2:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
   integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==


### PR DESCRIPTION
A few fixes to fix annoying warnings/errors in the console when testing and building the library. Mainly

- Remove `any` types
- Adjust jest roots
- Fix incorrect usage of react testing library