### PR TITLE
Add sandbox attritube to iframe to allow downloads with new privacy s…

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -149,11 +149,18 @@ define("WherebyEmbed", {
                 this.roomUrl.searchParams.set(k, v);
             }
         });
+
+        const isLocalRecordingEnabled = this.roomUrl.searchParams.has("recording");
+
+        if (isLocalRecordingEnabled)
+            this.iframe.sandbox = "allow-downloads allow-same-origin allow-forms allow-scripts allow-popups";
+
         this.html`
       <iframe
         ref=${this.iframe}
         src=${this.roomUrl}
-        allow="autoplay; camera; microphone; fullscreen; display-capture" sandbox="allow-downloads allow-same-origin allow-forms allow-scripts" />
+        allow="autoplay; camera; microphone; fullscreen; display-capture"
+        />
       `;
     },
 });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -153,7 +153,7 @@ define("WherebyEmbed", {
       <iframe
         ref=${this.iframe}
         src=${this.roomUrl}
-        allow="autoplay; camera; microphone; fullscreen; speaker; display-capture" />
+        allow="autoplay; camera; microphone; fullscreen; display-capture" sandbox="allow-downloads allow-same-origin allow-forms allow-scripts" />
       `;
     },
 });


### PR DESCRIPTION
…andbox settings
https://linear.app/whereby/issue/KOA-448/add-allow-downloads-to-the-iframe-injected-by-the-browser-sdk

Due to the upcoming privacy sandbox changes from Chrome, some issues are appearing when attempting to download local recordings from an iframe. 

Adding 'allow-downloads' is the first piece of the work toward allowing users to download local-recordings from in room experience rather than getting redirecting to the dashboard. I also removed the 'speaker' attribute that is no longer supported in chrome. 

Note: 
Since these changes involve sandboxing the iframe, several other exemptions were required to allow the in room experience to remain unchanged
- allow-scripts
- allow-same-origin
- allow-forms 
- allow pop ups

### **- EDIT: this should now only be applied if you have either the recording attribute on the embed element, or recording=on in the room url**:
eg: 
`<whereby-embed
      recording
      room={roomUrl}
    />` 

or: 
`<whereby-embed
      room="someroomurl.whereby.com?recording=on"
    />` 

### Test Plan
- Run the sdk in a test app
- Test out the in room experience, and observe no errors in the console 
- (the local recording download functionality will come with later tasks)