### PR TITLE
add toggle pip command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/browser-sdk",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Configurable web component for embedding Whereby video rooms in web applications",
   "author": "Whereby AS",
   "license": "MIT",

--- a/src/lib/__tests__/index.unit.js
+++ b/src/lib/__tests__/index.unit.js
@@ -78,6 +78,7 @@ describe("@whereby/browser-sdk", () => {
                     toggleMicrophone: expect.any(Function),
                     toggleScreenshare: expect.any(Function),
                     toggleChat: expect.any(Function),
+                    togglePip: expect.any(Function),
                 })
             );
         });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -98,6 +98,9 @@ define("WherebyEmbed", {
     toggleChat(enabled) {
         this._postCommand("toggle_chat", [enabled]);
     },
+    togglePip(enabled) {
+        this._postCommand("toggle_pip", [enabled]);
+    },
 
     onmessage({ origin, data }) {
         if (origin !== this.roomUrl.origin) return;


### PR DESCRIPTION
### Tested like
1. embed an iframe somewhere with this sdk version
2. document.querySelector("whereby-embed").togglePip()
3. see the error
4. click somewhere inside the iframe
5. do step 2 again
6. ???
7. profit


*The person approving this PR is REQUIRED to run the included test steps*

### Related tasks
https://linear.app/whereby/issue/PAN-345/add-embed-element-command-for-opening-and-closing-picture-in-picture

### Gotchas
This command works only if the iframe has focus (i.e. the user has
clicked inside the iframe)
If not, we show an error stating why PiP couldn't be enabled

### Screenshots
![Kapture 2023-10-24 at 11 50 24](https://github.com/whereby/pwa/assets/138459303/2d2aabbe-f7bf-418f-886a-64a201b64400)