### PR TITLE
Clean up room connection status

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     },
     "dependencies": {
         "@swc/helpers": "^0.3.13",
-        "@whereby/jslib-media": "whereby/jslib-media.git#1.3.2",
+        "@whereby/jslib-media": "whereby/jslib-media.git#1.3.3",
         "assert": "^2.0.0",
         "axios": "^1.2.3",
         "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha31",
+    "version": "2.0.0-beta1",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
     },
     "browserslist": "> 0.5%, last 2 versions, not dead",
     "source": "src/index.js",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
     "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.js"
+        "./react":  "./dist/react/index.js",
+        "./embed":  "./dist/embed/index.js",
+        "./utils":  "./dist/utils/index.js"
+    },
+    "typesVersions": {
+        "*": {
+            "react": ["dist/react/index.d.ts"],
+            "embed": ["dist/embed/index.d.ts"],
+            "utils": ["dist/utils/index.d.ts"]
         }
     },
     "files": [

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -34,7 +34,6 @@ import ServerSocket, {
 } from "@whereby/jslib-media/src/utils/ServerSocket";
 import { sdkVersion } from "./index";
 import LocalMedia from "./LocalMedia";
-import { RemoteParticipantState } from "./react/useRoomConnection";
 
 type Logger = Pick<Console, "debug" | "error" | "log" | "warn">;
 
@@ -203,18 +202,6 @@ export function handleStreamAdded(
     return new CustomEvent("screenshare_started", {
         detail: { participantId: clientId, stream, id: streamId, isLocal: false },
     });
-}
-
-// omit the internal props
-function convertRemoteParticipantToRemoteParticipantState(p: RemoteParticipant): RemoteParticipantState {
-    return {
-        displayName: p.displayName,
-        id: p.id,
-        isAudioEnabled: p.isAudioEnabled,
-        isLocalParticipant: p.isLocalParticipant,
-        isVideoEnabled: p.isVideoEnabled,
-        stream: p.stream,
-    };
 }
 
 /*
@@ -444,7 +431,7 @@ export default class RoomConnection extends TypedEventTarget {
         this._handleAcceptStreams([remoteParticipant]);
         this.dispatchEvent(
             new CustomEvent("participant_joined", {
-                detail: { remoteParticipant: convertRemoteParticipantToRemoteParticipantState(remoteParticipant) },
+                detail: { remoteParticipant },
             })
         );
     }
@@ -577,9 +564,7 @@ export default class RoomConnection extends TypedEventTarget {
                 new CustomEvent("room_joined", {
                     detail: {
                         localParticipant: this.localParticipant,
-                        remoteParticipants: this.remoteParticipants.map(
-                            convertRemoteParticipantToRemoteParticipantState
-                        ),
+                        remoteParticipants: this.remoteParticipants,
                         waitingParticipants: knockers.map((knocker) => {
                             return { id: knocker.clientId, displayName: knocker.displayName } as WaitingParticipant;
                         }),

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -15,14 +15,7 @@ import {
     RoomService,
 } from "./api";
 
-import {
-    LocalParticipant,
-    RemoteParticipant,
-    RemoteParticipantState,
-    Screenshare,
-    StreamState,
-    WaitingParticipant,
-} from "./RoomParticipant";
+import { LocalParticipant, RemoteParticipant, Screenshare, StreamState, WaitingParticipant } from "./RoomParticipant";
 
 import ServerSocket, {
     ChatMessage as SignalChatMessage,
@@ -41,6 +34,7 @@ import ServerSocket, {
 } from "@whereby/jslib-media/src/utils/ServerSocket";
 import { sdkVersion } from "./index";
 import LocalMedia from "./LocalMedia";
+import { RemoteParticipantState } from "./react/useRoomConnection";
 
 type Logger = Pick<Console, "debug" | "error" | "log" | "warn">;
 

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -56,7 +56,7 @@ export type RoomConnectionStatus =
     | "disconnecting"
     | "disconnected"
     | "accepted"
-    | "rejected";
+    | "knock_rejected";
 
 export type CloudRecordingState = {
     status: "recording";
@@ -491,7 +491,7 @@ export default class RoomConnection extends TypedEventTarget {
             this._roomKey = payload.metadata.roomKey;
             this._joinRoom();
         } else if (resolution === "rejected") {
-            this.roomConnectionStatus = "rejected";
+            this.roomConnectionStatus = "knock_rejected";
 
             this.dispatchEvent(
                 new CustomEvent("room_connection_status_changed", {

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -88,6 +88,7 @@ export type ParticipantLeftEvent = {
 export type ParticipantStreamAddedEvent = {
     participantId: string;
     stream: MediaStream;
+    streamId: string;
 };
 
 export type ParticipantAudioEnabledEvent = {
@@ -211,7 +212,13 @@ export function handleStreamAdded(
     }
     // screenshare
     return new RoomEvent("screenshare_started", {
-        detail: { participantId: clientId, stream, id: streamId, isLocal: false },
+        detail: {
+            participantId: clientId,
+            stream,
+            id: streamId,
+            isLocal: false,
+            hasAudioTrack: stream.getAudioTracks().length > 0,
+        },
     });
 }
 
@@ -966,7 +973,9 @@ export default class RoomConnection extends TypedEventTarget {
 
             this.rtcManager?.removeStream(id, this.localMedia.screenshareStream, null);
             this.screenshares = this.screenshares.filter((s) => s.id !== id);
-            this.dispatchEvent(new RoomEvent("screenshare_stopped", { detail: { participantId: this.selfId, id } }));
+            this.dispatchEvent(
+                new RoomEvent("screenshare_stopped", { detail: { participantId: this.selfId || "", id } })
+            );
             this.localMedia.stopScreenshare();
         }
     }

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -157,6 +157,17 @@ export interface RoomEventsMap {
     waiting_participant_left: (e: CustomEvent<WaitingParticipantLeftEvent>) => void;
 }
 
+type ArgType<T> = T extends (arg: infer U) => unknown ? U : never;
+type RoomEventKey = keyof RoomEventsMap;
+type RoomEventHandler<T extends RoomEventKey> = RoomEventsMap[T];
+type RoomEventType<T extends RoomEventKey> = ArgType<RoomEventHandler<T>>;
+type RoomEventPayload<T extends RoomEventKey> = RoomEventType<T> extends CustomEvent<infer U> ? U : never;
+class RoomEvent<T extends RoomEventKey> extends CustomEvent<RoomEventPayload<T>> {
+    constructor(eventType: T, eventInitDict?: CustomEventInit<RoomEventPayload<T>>) {
+        super(eventType, eventInitDict);
+    }
+}
+
 const API_BASE_URL = process.env["REACT_APP_API_BASE_URL"] || "https://api.whereby.dev";
 const SIGNAL_BASE_URL = process.env["REACT_APP_SIGNAL_BASE_URL"] || "wss://signal.appearin.net";
 
@@ -196,10 +207,10 @@ export function handleStreamAdded(
         (!remoteParticipant.stream && streamType === "webcam") ||
         (!remoteParticipant.stream && !streamType && remoteParticipant.streams.indexOf(remoteParticipantStream) < 1)
     ) {
-        return new CustomEvent("participant_stream_added", { detail: { participantId: clientId, stream, streamId } });
+        return new RoomEvent("participant_stream_added", { detail: { participantId: clientId, stream, streamId } });
     }
     // screenshare
-    return new CustomEvent("screenshare_started", {
+    return new RoomEvent("screenshare_started", {
         detail: { participantId: clientId, stream, id: streamId, isLocal: false },
     });
 }
@@ -345,12 +356,12 @@ export default class RoomConnection extends TypedEventTarget {
         this.localMedia.addEventListener("camera_enabled", (e) => {
             const { enabled } = e.detail;
             this.signalSocket.emit("enable_video", { enabled });
-            this.dispatchEvent(new CustomEvent("local_camera_enabled", { detail: { enabled } }));
+            this.dispatchEvent(new RoomEvent("local_camera_enabled", { detail: { enabled } }));
         });
         this.localMedia.addEventListener("microphone_enabled", (e) => {
             const { enabled } = e.detail;
             this.signalSocket.emit("enable_audio", { enabled });
-            this.dispatchEvent(new CustomEvent("local_microphone_enabled", { detail: { enabled } }));
+            this.dispatchEvent(new RoomEvent("local_microphone_enabled", { detail: { enabled } }));
         });
 
         const webrtcProvider = {
@@ -385,12 +396,12 @@ export default class RoomConnection extends TypedEventTarget {
     }
 
     private _handleNewChatMessage(message: SignalChatMessage) {
-        this.dispatchEvent(new CustomEvent("chat_message", { detail: message }));
+        this.dispatchEvent(new RoomEvent("chat_message", { detail: message }));
     }
 
     private _handleCloudRecordingStarted({ client }: { client: SignalClient }) {
         this.dispatchEvent(
-            new CustomEvent("cloud_recording_started", {
+            new RoomEvent("cloud_recording_started", {
                 detail: {
                     status: "recording",
                     startedAt: client.startedCloudRecordingAt
@@ -403,7 +414,7 @@ export default class RoomConnection extends TypedEventTarget {
 
     private _handleStreamingStarted() {
         this.dispatchEvent(
-            new CustomEvent("streaming_started", {
+            new RoomEvent("streaming_started", {
                 detail: {
                     status: "streaming",
                     // We don't have the streaming start time stored on the
@@ -430,7 +441,7 @@ export default class RoomConnection extends TypedEventTarget {
         this.remoteParticipants = [...this.remoteParticipants, remoteParticipant];
         this._handleAcceptStreams([remoteParticipant]);
         this.dispatchEvent(
-            new CustomEvent("participant_joined", {
+            new RoomEvent("participant_joined", {
                 detail: { remoteParticipant },
             })
         );
@@ -442,7 +453,7 @@ export default class RoomConnection extends TypedEventTarget {
         if (!remoteParticipant) {
             return;
         }
-        this.dispatchEvent(new CustomEvent("participant_left", { detail: { participantId: remoteParticipant.id } }));
+        this.dispatchEvent(new RoomEvent("participant_left", { detail: { participantId: remoteParticipant.id } }));
     }
 
     private _handleClientAudioEnabled({ clientId, isAudioEnabled }: { clientId: string; isAudioEnabled: boolean }) {
@@ -451,7 +462,7 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
         this.dispatchEvent(
-            new CustomEvent("participant_audio_enabled", {
+            new RoomEvent("participant_audio_enabled", {
                 detail: { participantId: remoteParticipant.id, isAudioEnabled },
             })
         );
@@ -463,7 +474,7 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
         this.dispatchEvent(
-            new CustomEvent("participant_video_enabled", {
+            new RoomEvent("participant_video_enabled", {
                 detail: { participantId: remoteParticipant.id, isVideoEnabled },
             })
         );
@@ -475,7 +486,7 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
         this.dispatchEvent(
-            new CustomEvent("participant_metadata_changed", {
+            new RoomEvent("participant_metadata_changed", {
                 detail: { participantId: remoteParticipant.id, displayName },
             })
         );
@@ -496,7 +507,7 @@ export default class RoomConnection extends TypedEventTarget {
             this.connectionStatus = "knock_rejected";
 
             this.dispatchEvent(
-                new CustomEvent("connection_status_changed", {
+                new RoomEvent("connection_status_changed", {
                     detail: {
                         connectionStatus: this.connectionStatus,
                     },
@@ -509,7 +520,7 @@ export default class RoomConnection extends TypedEventTarget {
         const { clientId } = payload;
 
         this.dispatchEvent(
-            new CustomEvent("waiting_participant_left", {
+            new RoomEvent("waiting_participant_left", {
                 detail: { participantId: clientId },
             })
         );
@@ -521,7 +532,7 @@ export default class RoomConnection extends TypedEventTarget {
         if (error === "room_locked" && isLocked) {
             this.connectionStatus = "room_locked";
             this.dispatchEvent(
-                new CustomEvent("connection_status_changed", {
+                new RoomEvent("connection_status_changed", {
                     detail: {
                         connectionStatus: this.connectionStatus,
                     },
@@ -560,8 +571,9 @@ export default class RoomConnection extends TypedEventTarget {
                 .map((c) => new RemoteParticipant({ ...c, newJoiner: false }));
 
             this.connectionStatus = "connected";
+
             this.dispatchEvent(
-                new CustomEvent("room_joined", {
+                new RoomEvent("room_joined", {
                     detail: {
                         localParticipant: this.localParticipant,
                         remoteParticipants: this.remoteParticipants,
@@ -578,7 +590,7 @@ export default class RoomConnection extends TypedEventTarget {
         const { clientId, displayName } = event;
 
         this.dispatchEvent(
-            new CustomEvent("waiting_participant_joined", {
+            new RoomEvent("waiting_participant_joined", {
                 detail: { participantId: clientId, displayName },
             })
         );
@@ -596,7 +608,7 @@ export default class RoomConnection extends TypedEventTarget {
     private _handleDisconnect() {
         this.connectionStatus = "disconnected";
         this.dispatchEvent(
-            new CustomEvent("connection_status_changed", {
+            new RoomEvent("connection_status_changed", {
                 detail: {
                     connectionStatus: this.connectionStatus,
                 },
@@ -605,11 +617,11 @@ export default class RoomConnection extends TypedEventTarget {
     }
 
     private _handleCloudRecordingStopped() {
-        this.dispatchEvent(new CustomEvent("cloud_recording_stopped"));
+        this.dispatchEvent(new RoomEvent("cloud_recording_stopped"));
     }
 
     private _handleStreamingStopped() {
-        this.dispatchEvent(new CustomEvent("streaming_stopped"));
+        this.dispatchEvent(new RoomEvent("streaming_stopped"));
     }
 
     private _handleScreenshareStarted(screenshare: SignalScreenshareStartedEvent) {
@@ -647,7 +659,7 @@ export default class RoomConnection extends TypedEventTarget {
 
         remoteParticipant.removeStream(id);
         this.screenshares = this.screenshares.filter((s) => !(s.participantId === participantId && s.id === id));
-        this.dispatchEvent(new CustomEvent("screenshare_stopped", { detail: { participantId, id } }));
+        this.dispatchEvent(new RoomEvent("screenshare_stopped", { detail: { participantId, id } }));
     }
 
     private _handleRtcEvent<K extends keyof RtcEvents>(eventName: K, data: RtcEvents[K]) {
@@ -792,7 +804,7 @@ export default class RoomConnection extends TypedEventTarget {
         this.signalSocket.connect();
         this.connectionStatus = "connecting";
         this.dispatchEvent(
-            new CustomEvent("connection_status_changed", {
+            new RoomEvent("connection_status_changed", {
                 detail: {
                     connectionStatus: this.connectionStatus,
                 },
@@ -823,7 +835,7 @@ export default class RoomConnection extends TypedEventTarget {
     public knock() {
         this.connectionStatus = "knocking";
         this.dispatchEvent(
-            new CustomEvent("connection_status_changed", {
+            new RoomEvent("connection_status_changed", {
                 detail: {
                     connectionStatus: this.connectionStatus,
                 },
@@ -937,7 +949,7 @@ export default class RoomConnection extends TypedEventTarget {
         ];
 
         this.dispatchEvent(
-            new CustomEvent("screenshare_started", {
+            new RoomEvent("screenshare_started", {
                 detail: {
                     participantId: this.selfId || "",
                     id: screenshareStream.id,
@@ -954,7 +966,7 @@ export default class RoomConnection extends TypedEventTarget {
 
             this.rtcManager?.removeStream(id, this.localMedia.screenshareStream, null);
             this.screenshares = this.screenshares.filter((s) => s.id !== id);
-            this.dispatchEvent(new CustomEvent("screenshare_stopped", { detail: { participantId: this.selfId, id } }));
+            this.dispatchEvent(new RoomEvent("screenshare_stopped", { detail: { participantId: this.selfId, id } }));
             this.localMedia.stopScreenshare();
         }
     }

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -55,7 +55,6 @@ export type RoomConnectionStatus =
     | "knocking"
     | "disconnecting"
     | "disconnected"
-    | "accepted"
     | "knock_rejected";
 
 export type CloudRecordingState = {
@@ -487,7 +486,6 @@ export default class RoomConnection extends TypedEventTarget {
         }
 
         if (resolution === "accepted") {
-            this.roomConnectionStatus = "accepted";
             this._roomKey = payload.metadata.roomKey;
             this._joinRoom();
         } else if (resolution === "rejected") {

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -32,7 +32,7 @@ import ServerSocket, {
     ScreenshareStartedEvent as SignalScreenshareStartedEvent,
     ScreenshareStoppedEvent as SignalScreenshareStoppedEvent,
 } from "@whereby/jslib-media/src/utils/ServerSocket";
-import { sdkVersion } from "./index";
+import { sdkVersion } from "./version";
 import LocalMedia from "./LocalMedia";
 
 type Logger = Pick<Console, "debug" | "error" | "log" | "warn">;

--- a/src/lib/RoomParticipant.ts
+++ b/src/lib/RoomParticipant.ts
@@ -79,11 +79,6 @@ export class RemoteParticipant extends RoomParticipant {
     }
 }
 
-export type RemoteParticipantState = Omit<
-    RemoteParticipant,
-    "updateStreamState" | "newJoiner" | "streams" | "addStream" | "removeStream"
->;
-
 export class LocalParticipant extends RoomParticipant {
     public readonly isLocalParticipant = true;
 

--- a/src/lib/RoomParticipant.ts
+++ b/src/lib/RoomParticipant.ts
@@ -87,8 +87,6 @@ export class LocalParticipant extends RoomParticipant {
     }
 }
 
-export type LocalParticipantState = LocalParticipant;
-
 export interface WaitingParticipant {
     id: string;
     displayName: string | null;

--- a/src/lib/RoomParticipant.ts
+++ b/src/lib/RoomParticipant.ts
@@ -79,7 +79,10 @@ export class RemoteParticipant extends RoomParticipant {
     }
 }
 
-export type RemoteParticipantState = Omit<RemoteParticipant, "updateStreamState">;
+export type RemoteParticipantState = Omit<
+    RemoteParticipant,
+    "updateStreamState" | "newJoiner" | "streams" | "addStream" | "removeStream"
+>;
 
 export class LocalParticipant extends RoomParticipant {
     public readonly isLocalParticipant = true;

--- a/src/lib/__tests__/RoomConnection.spec.ts
+++ b/src/lib/__tests__/RoomConnection.spec.ts
@@ -99,6 +99,12 @@ describe("handleStreamAdded", () => {
         });
 
         expect(res?.type).toEqual("screenshare_started");
-        expect(res?.detail).toEqual({ participantId: clientId, stream, id: streamId, isLocal: false });
+        expect(res?.detail).toEqual({
+            participantId: clientId,
+            stream,
+            id: streamId,
+            isLocal: false,
+            hasAudioTrack: false,
+        });
     });
 });

--- a/src/lib/embed/index.ts
+++ b/src/lib/embed/index.ts
@@ -1,4 +1,5 @@
 import { define, ref } from "heresy";
+export { sdkVersion } from "../version";
 
 interface WherebyEmbedAttributes {
     audio: string;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,11 +2,6 @@ import "./embed";
 export { useLocalMedia, useRoomConnection, VideoView } from "./react";
 export { default as fakeWebcamFrame } from "./utils/fakeWebcamFrame";
 export { default as fakeAudioStream } from "./utils/fakeAudioStream";
-export type {
-    RemoteParticipantState as RemoteParticipant,
-    LocalParticipantState as LocalParticipant,
-    WaitingParticipant,
-    Screenshare,
-} from "./RoomParticipant";
+export type { LocalParticipantState as LocalParticipant, WaitingParticipant, Screenshare } from "./RoomParticipant";
 export type { ChatMessage } from "./RoomConnection";
 export const sdkVersion = "__SDK_VERSION__";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,0 @@
-import "./embed";
-export { useLocalMedia, useRoomConnection, VideoView } from "./react";
-export { default as fakeWebcamFrame } from "./utils/fakeWebcamFrame";
-export { default as fakeAudioStream } from "./utils/fakeAudioStream";
-export type { LocalParticipantState as LocalParticipant, WaitingParticipant, Screenshare } from "./RoomParticipant";
-export type { ChatMessage } from "./RoomConnection";
-export const sdkVersion = "__SDK_VERSION__";

--- a/src/lib/react/index.ts
+++ b/src/lib/react/index.ts
@@ -1,3 +1,13 @@
 export { default as VideoView } from "./VideoView";
 export { default as useLocalMedia } from "./useLocalMedia";
 export { useRoomConnection } from "./useRoomConnection";
+export { default as LocalMedia } from "../LocalMedia";
+export { default as RoomConnection } from "../RoomConnection";
+export type {
+    RemoteParticipantState as RemoteParticipant,
+    LocalParticipantState as LocalParticipant,
+    WaitingParticipant,
+    Screenshare,
+} from "../RoomParticipant";
+export type { ChatMessage } from "../RoomConnection";
+export { sdkVersion } from "../version";

--- a/src/lib/react/index.ts
+++ b/src/lib/react/index.ts
@@ -1,8 +1,6 @@
 export { default as VideoView } from "./VideoView";
 export { default as useLocalMedia } from "./useLocalMedia";
 export { useRoomConnection } from "./useRoomConnection";
-export { default as LocalMedia } from "../LocalMedia";
-export { default as RoomConnection } from "../RoomConnection";
 export type {
     RemoteParticipantState as RemoteParticipant,
     LocalParticipantState as LocalParticipant,

--- a/src/lib/react/index.ts
+++ b/src/lib/react/index.ts
@@ -1,11 +1,16 @@
 export { default as VideoView } from "./VideoView";
 export { default as useLocalMedia } from "./useLocalMedia";
 export { useRoomConnection } from "./useRoomConnection";
+
+export type { LocalMediaRef as UseLocalMediaResult } from "./useLocalMedia";
+
 export type {
-    RemoteParticipantState as RemoteParticipant,
+    ChatMessageState as ChatMessage,
     LocalParticipantState as LocalParticipant,
-    WaitingParticipant,
-    Screenshare,
-} from "../RoomParticipant";
-export type { ChatMessage } from "../RoomConnection";
+    RemoteParticipantState as RemoteParticipant,
+    RoomConnectionState as RoomConnection,
+    ScreenshareState as Screenshare,
+    WaitingParticipantState as WaitingParticipant,
+} from "./useRoomConnection";
+
 export { sdkVersion } from "../version";

--- a/src/lib/react/useLocalMedia.ts
+++ b/src/lib/react/useLocalMedia.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useState } from "react";
-import { LocalMedia } from "./";
+import LocalMedia from "../LocalMedia";
 
 interface LocalMediaState {
     currentCameraDeviceId?: string;

--- a/src/lib/react/useLocalMedia.ts
+++ b/src/lib/react/useLocalMedia.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useState } from "react";
-import LocalMedia from "../LocalMedia";
+import { LocalMedia } from "./";
 
 interface LocalMediaState {
     currentCameraDeviceId?: string;

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -5,7 +5,7 @@ import RoomConnection, {
     ChatMessage,
     CloudRecordingState,
     RoomConnectionOptions,
-    RoomConnectionStatus,
+    ConnectionStatus,
     RoomEventsMap,
     LiveStreamState,
 } from "../RoomConnection";
@@ -20,7 +20,7 @@ export interface RoomConnectionState {
     mostRecentChatMessage?: ChatMessage;
     remoteParticipants: RemoteParticipantState[];
     screenshares: Screenshare[];
-    roomConnectionStatus: RoomConnectionStatus;
+    connectionStatus: ConnectionStatus;
     liveStream?: LiveStreamState;
     waitingParticipants: WaitingParticipant[];
 }
@@ -29,7 +29,7 @@ const initialState: RoomConnectionState = {
     chatMessages: [],
     isStartingScreenshare: false,
     remoteParticipants: [],
-    roomConnectionStatus: "initializing",
+    connectionStatus: "initializing",
     screenshares: [],
     waitingParticipants: [],
 };
@@ -55,9 +55,9 @@ type RoomConnectionEvent =
           };
       }
     | {
-          type: "ROOM_CONNECTION_STATUS_CHANGED";
+          type: "CONNECTION_STATUS_CHANGED";
           payload: {
-              roomConnectionStatus: RoomConnectionStatus;
+              connectionStatus: ConnectionStatus;
           };
       }
     | {
@@ -215,12 +215,12 @@ function reducer(state: RoomConnectionState, action: RoomConnectionEvent): RoomC
                 localParticipant: action.payload.localParticipant,
                 remoteParticipants: action.payload.remoteParticipants,
                 waitingParticipants: action.payload.waitingParticipants,
-                roomConnectionStatus: "connected",
+                connectionStatus: "connected",
             };
-        case "ROOM_CONNECTION_STATUS_CHANGED":
+        case "CONNECTION_STATUS_CHANGED":
             return {
                 ...state,
-                roomConnectionStatus: action.payload.roomConnectionStatus,
+                connectionStatus: action.payload.connectionStatus,
             };
         case "PARTICIPANT_AUDIO_ENABLED":
             return {
@@ -444,11 +444,11 @@ export function useRoomConnection(roomUrl: string, roomConnectionOptions: UseRoo
                 const { participantId, isVideoEnabled } = e.detail;
                 dispatch({ type: "PARTICIPANT_VIDEO_ENABLED", payload: { participantId, isVideoEnabled } });
             }),
-            createEventListener("room_connection_status_changed", (e) => {
-                const { roomConnectionStatus } = e.detail;
+            createEventListener("connection_status_changed", (e) => {
+                const { connectionStatus } = e.detail;
                 dispatch({
-                    type: "ROOM_CONNECTION_STATUS_CHANGED",
-                    payload: { roomConnectionStatus },
+                    type: "CONNECTION_STATUS_CHANGED",
+                    payload: { connectionStatus },
                 });
             }),
             createEventListener("room_joined", (e) => {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -9,12 +9,23 @@ import RoomConnection, {
     RoomEventsMap,
     LiveStreamState,
 } from "../RoomConnection";
-import { LocalParticipantState, RemoteParticipant, Screenshare, WaitingParticipant } from "../RoomParticipant";
+import { LocalParticipant, RemoteParticipant, Screenshare, WaitingParticipant } from "../RoomParticipant";
 
 export type RemoteParticipantState = Omit<
     RemoteParticipant,
     "updateStreamState" | "newJoiner" | "streams" | "addStream" | "removeStream"
 >;
+export type LocalParticipantState = LocalParticipant;
+export interface WaitingParticipantState {
+    id: string;
+    displayName: string | null;
+}
+export interface ChatMessageState {
+    senderId: string;
+    timestamp: string;
+    text: string;
+}
+export type ScreenshareState = Screenshare;
 
 type LocalScreenshareStatus = "starting" | "active";
 
@@ -27,7 +38,7 @@ export interface RoomConnectionState {
     screenshares: Screenshare[];
     connectionStatus: ConnectionStatus;
     liveStream?: LiveStreamState;
-    waitingParticipants: WaitingParticipant[];
+    waitingParticipants: WaitingParticipantState[];
 }
 
 const initialState: RoomConnectionState = {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -378,7 +378,17 @@ export type RoomConnectionRef = {
     _ref: RoomConnection;
 };
 
-export function useRoomConnection(roomUrl: string, roomConnectionOptions: UseRoomConnectionOptions): RoomConnectionRef {
+const defaultRoomConnectionOptions: UseRoomConnectionOptions = {
+    localMediaConstraints: {
+        audio: true,
+        video: true,
+    },
+};
+
+export function useRoomConnection(
+    roomUrl: string,
+    roomConnectionOptions = defaultRoomConnectionOptions
+): RoomConnectionRef {
     const [roomConnection] = useState<RoomConnection>(
         () =>
             new RoomConnection(roomUrl, {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -15,7 +15,6 @@ export interface RoomConnectionState {
     chatMessages: ChatMessage[];
     cloudRecording?: CloudRecordingState;
     isStartingScreenshare: boolean;
-    startScreenshareError?: unknown;
     localParticipant?: LocalParticipantState;
     remoteParticipants: RemoteParticipantState[];
     screenshares: Screenshare[];
@@ -286,7 +285,6 @@ function reducer(state: RoomConnectionState, action: RoomConnectionEvent): RoomC
             return {
                 ...state,
                 isStartingScreenshare: false,
-                startScreenshareError: action.payload,
             };
         case "LOCAL_SCREENSHARE_STARTING":
             return {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -9,7 +9,12 @@ import RoomConnection, {
     RoomEventsMap,
     LiveStreamState,
 } from "../RoomConnection";
-import { LocalParticipantState, RemoteParticipantState, Screenshare, WaitingParticipant } from "../RoomParticipant";
+import { LocalParticipantState, RemoteParticipant, Screenshare, WaitingParticipant } from "../RoomParticipant";
+
+export type RemoteParticipantState = Omit<
+    RemoteParticipant,
+    "updateStreamState" | "newJoiner" | "streams" | "addStream" | "removeStream"
+>;
 
 type LocalScreenshareStatus = "starting" | "active";
 

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -187,6 +187,18 @@ function updateParticipant(
     ];
 }
 
+// omit the internal props
+function convertRemoteParticipantToRemoteParticipantState(p: RemoteParticipant): RemoteParticipantState {
+    return {
+        displayName: p.displayName,
+        id: p.id,
+        isAudioEnabled: p.isAudioEnabled,
+        isLocalParticipant: p.isLocalParticipant,
+        isVideoEnabled: p.isVideoEnabled,
+        stream: p.stream,
+    };
+}
+
 function addScreenshare(screenshares: Screenshare[], screenshare: Screenshare): Screenshare[] {
     const existingScreenshare = screenshares.find((ss) => ss.id === screenshare.id);
     if (existingScreenshare) {
@@ -447,7 +459,12 @@ export function useRoomConnection(
             }),
             createEventListener("participant_joined", (e) => {
                 const { remoteParticipant } = e.detail;
-                dispatch({ type: "PARTICIPANT_JOINED", payload: { paritipant: remoteParticipant } });
+                dispatch({
+                    type: "PARTICIPANT_JOINED",
+                    payload: {
+                        paritipant: convertRemoteParticipantToRemoteParticipantState(remoteParticipant),
+                    },
+                });
             }),
             createEventListener("participant_left", (e) => {
                 const { participantId } = e.detail;
@@ -476,7 +493,11 @@ export function useRoomConnection(
                 const { localParticipant, remoteParticipants, waitingParticipants } = e.detail;
                 dispatch({
                     type: "ROOM_JOINED",
-                    payload: { localParticipant, remoteParticipants, waitingParticipants },
+                    payload: {
+                        localParticipant,
+                        remoteParticipants: remoteParticipants.map(convertRemoteParticipantToRemoteParticipantState),
+                        waitingParticipants,
+                    },
                 });
             }),
             createEventListener("screenshare_started", (e) => {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -17,7 +17,6 @@ export interface RoomConnectionState {
     isStartingScreenshare: boolean;
     startScreenshareError?: unknown;
     localParticipant?: LocalParticipantState;
-    mostRecentChatMessage?: ChatMessage;
     remoteParticipants: RemoteParticipantState[];
     screenshares: Screenshare[];
     connectionStatus: ConnectionStatus;
@@ -194,7 +193,6 @@ function reducer(state: RoomConnectionState, action: RoomConnectionEvent): RoomC
             return {
                 ...state,
                 chatMessages: [...state.chatMessages, action.payload],
-                mostRecentChatMessage: action.payload,
             };
         case "CLOUD_RECORDING_STARTED":
             return {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,2 @@
+export { default as fakeAudioStream } from "./fakeAudioStream";
+export { default as fakeWebcamFrame } from "./fakeWebcamFrame";

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,1 @@
+export const sdkVersion = "__SDK_VERSION__";

--- a/src/stories/components/VideoExperience.tsx
+++ b/src/stories/components/VideoExperience.tsx
@@ -52,7 +52,7 @@ export default function VideoExperience({
                 </div>
             )}
             {roomConnectionStatus === "knocking" && <span>Knocking...</span>}
-            {roomConnectionStatus === "rejected" && <span>Rejected :(</span>}
+            {roomConnectionStatus === "knock_rejected" && <span>Rejected :(</span>}
             {roomConnectionStatus === "connected" && (
                 <>
                     <div className="chat">

--- a/src/stories/components/VideoExperience.tsx
+++ b/src/stories/components/VideoExperience.tsx
@@ -25,7 +25,6 @@ export default function VideoExperience({
 
     const {
         localParticipant,
-        mostRecentChatMessage,
         remoteParticipants,
         connectionStatus,
         waitingParticipants,
@@ -56,7 +55,6 @@ export default function VideoExperience({
             {connectionStatus === "connected" && (
                 <>
                     <div className="chat">
-                        <div className="last_message">{mostRecentChatMessage?.text}</div>
                         <form
                             onSubmit={(e) => {
                                 e.preventDefault();

--- a/src/stories/components/VideoExperience.tsx
+++ b/src/stories/components/VideoExperience.tsx
@@ -27,7 +27,7 @@ export default function VideoExperience({
         localParticipant,
         mostRecentChatMessage,
         remoteParticipants,
-        roomConnectionStatus,
+        connectionStatus,
         waitingParticipants,
         screenshares,
     } = state;
@@ -44,16 +44,16 @@ export default function VideoExperience({
 
     return (
         <div>
-            {roomConnectionStatus === "connecting" && <span>Connecting...</span>}
-            {roomConnectionStatus === "room_locked" && (
+            {connectionStatus === "connecting" && <span>Connecting...</span>}
+            {connectionStatus === "room_locked" && (
                 <div style={{ color: "red" }}>
                     <span>Room locked, please knock....</span>
                     <button onClick={() => knock()}>Knock</button>
                 </div>
             )}
-            {roomConnectionStatus === "knocking" && <span>Knocking...</span>}
-            {roomConnectionStatus === "knock_rejected" && <span>Rejected :(</span>}
-            {roomConnectionStatus === "connected" && (
+            {connectionStatus === "knocking" && <span>Knocking...</span>}
+            {connectionStatus === "knock_rejected" && <span>Rejected :(</span>}
+            {connectionStatus === "connected" && (
                 <>
                     <div className="chat">
                         <div className="last_message">{mostRecentChatMessage?.text}</div>

--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -52,7 +52,7 @@ export const LocalMediaOnly = () => {
 function CanvasInRoom({ localMedia, roomUrl }: { localMedia: LocalMediaRef; roomUrl: string }) {
     const { state } = useRoomConnection(roomUrl, { localMedia });
 
-    return <div>Room connection status: {state.roomConnectionStatus}</div>;
+    return <div>Room connection status: {state.connectionStatus}</div>;
 }
 
 function LocalMediaWithCanvasStream_({ canvasStream, roomUrl }: { canvasStream: MediaStream; roomUrl: string }) {

--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -40,7 +40,7 @@ export const RoomConnectionWithLocalMedia = ({ roomUrl, displayName }: { roomUrl
 };
 
 export const LocalMediaOnly = () => {
-    const localMedia = useLocalMedia({ audio: true, video: true });
+    const localMedia = useLocalMedia();
 
     return (
         <div>

--- a/test/sample-app/src/App.tsx
+++ b/test/sample-app/src/App.tsx
@@ -83,7 +83,7 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         return <WaitingArea knock={knock} />;
     }
 
-    if (roomConnectionStatus === "rejected") {
+    if (roomConnectionStatus === "knock_rejected") {
         return <p data-testid="knockRejectedMessage">You have been rejected access</p>;
     }
 

--- a/test/sample-app/src/App.tsx
+++ b/test/sample-app/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useRoomConnection, useLocalMedia } from "@whereby.com/browser-sdk/react";
+import { useRoomConnection, useLocalMedia, UseLocalMediaResult } from "@whereby.com/browser-sdk/react";
 import { fakeAudioStream, fakeWebcamFrame } from "@whereby.com/browser-sdk/utils";
 
 import "./App.css";
@@ -33,11 +33,9 @@ const ChatInput = ({ sendChatMessage }: { sendChatMessage: (message: string) => 
     );
 };
 
-type LocalMediaRef = ReturnType<typeof useLocalMedia>;
-
 type RoomProps = {
     roomUrl: string;
-    localMedia: LocalMediaRef;
+    localMedia: UseLocalMediaResult;
     displayName: string;
     isHost: boolean;
 };

--- a/test/sample-app/src/App.tsx
+++ b/test/sample-app/src/App.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useRoomConnection, useLocalMedia, fakeAudioStream, fakeWebcamFrame } from "@whereby.com/browser-sdk";
+import { useRoomConnection, useLocalMedia } from "@whereby.com/browser-sdk/react";
+import { fakeAudioStream, fakeWebcamFrame } from "@whereby.com/browser-sdk/utils";
+
 import "./App.css";
 
 const WaitingArea = ({ knock }: { knock: () => void }) => {

--- a/test/sample-app/src/App.tsx
+++ b/test/sample-app/src/App.tsx
@@ -53,7 +53,7 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         waitingParticipants,
         remoteParticipants,
         localParticipant,
-        roomConnectionStatus,
+        connectionStatus,
         chatMessages,
         cloudRecording,
         liveStream,
@@ -79,11 +79,11 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         setIsMicrophoneEnabled(localParticipant?.isAudioEnabled || false);
     }, [localParticipant?.isAudioEnabled]);
 
-    if (roomConnectionStatus === "room_locked") {
+    if (connectionStatus === "room_locked") {
         return <WaitingArea knock={knock} />;
     }
 
-    if (roomConnectionStatus === "knock_rejected") {
+    if (connectionStatus === "knock_rejected") {
         return <p data-testid="knockRejectedMessage">You have been rejected access</p>;
     }
 
@@ -91,8 +91,8 @@ const Room = ({ roomUrl, localMedia, displayName, isHost }: RoomProps) => {
         <div>
             <h1>Room</h1>
             <dl>
-                <dt>Room Connection Status</dt>
-                <dd data-testid="roomConnectionStatus">{roomConnectionStatus}</dd>
+                <dt>Connection Status</dt>
+                <dd data-testid="connectionStatus">{connectionStatus}</dd>
                 <dt>Local client ID</dt>
                 <dd data-testid="localClientId">{localParticipant?.id || "N/A"}</dd>
                 <dt>Cloud recording status</dt>

--- a/test/sample-app/yarn.lock
+++ b/test/sample-app/yarn.lock
@@ -2401,24 +2401,24 @@
     "@xtuc/long" "4.2.2"
 
 "@whereby.com/browser-sdk@file:.yalc/@whereby.com/browser-sdk":
-  version "2.0.0-alpha32"
+  version "2.0.0-beta1"
   dependencies:
     "@swc/helpers" "^0.3.13"
-    "@whereby/jslib-media" whereby/jslib-media.git#1.3.2
+    "@whereby/jslib-media" whereby/jslib-media.git#1.3.3
     assert "^2.0.0"
     axios "^1.2.3"
     btoa "^1.2.1"
     events "^3.3.0"
     heresy "^1.0.4"
 
-"@whereby/jslib-media@whereby/jslib-media.git#1.3.2":
-  version "1.3.2"
-  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/231dd5e11c30e4b601fda0a47543e72f19f6fbf1"
+"@whereby/jslib-media@whereby/jslib-media.git#1.3.3":
+  version "1.3.3"
+  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/1fb844d4b52769a2adb620c26496422e13805d21"
   dependencies:
     assert "^2.0.0"
     events "^3.3.0"
     mediasoup-client "3.6.100"
-    rtcstats "github:lifeonairteam/rtcstats#v3.1.0"
+    rtcstats "github:whereby/rtcstats#v5.3.0"
     sdp "^2.2.0"
     sdp-transform "^2.14.1"
     socket.io-client "4.7.2"
@@ -8254,9 +8254,9 @@ rtcpeerconnection-shim@^1.2.15:
   dependencies:
     sdp "^2.6.0"
 
-"rtcstats@github:lifeonairteam/rtcstats#v3.1.0":
-  version "3.0.3"
-  resolved "https://codeload.github.com/lifeonairteam/rtcstats/tar.gz/8d46fedd3031ccdc52e7ec8525207e11dbb3115f"
+"rtcstats@github:whereby/rtcstats#v5.3.0":
+  version "5.3.0"
+  resolved "https://codeload.github.com/whereby/rtcstats/tar.gz/f696794035acc18a0d42229217a9a3b7630d524e"
 
 run-parallel@^1.1.9:
   version "1.2.0"

--- a/test/sample-app/yarn.lock
+++ b/test/sample-app/yarn.lock
@@ -1882,7 +1882,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/debug@^4.1.10":
+"@types/debug@^4.1.8":
   version "4.1.10"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.10.tgz#f23148a6eb771a34c466a4fc28379d8101e84494"
   integrity sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==
@@ -2400,28 +2400,31 @@
     "@webassemblyjs/ast" "1.11.6"
     "@xtuc/long" "4.2.2"
 
-"@whereby.com/browser-sdk@2.0.0":
-  version "2.0.0-alpha20"
-  resolved "https://registry.yarnpkg.com/@whereby.com/browser-sdk/-/browser-sdk-2.0.0-alpha20.tgz#7f96ff1da148fbef431f33d38257e57d94a77493"
-  integrity sha512-KzCEnAI5toKbuXtQPeNsFCp6+wQpvorstcpFCExYWz3JuB2CROrEQp1oL3do1WLzh7mqYm0okwFVRYDqAjbAmg==
+"@whereby.com/browser-sdk@file:.yalc/@whereby.com/browser-sdk":
+  version "2.0.0-alpha32"
   dependencies:
     "@swc/helpers" "^0.3.13"
-    "@whereby/jslib-media" whereby/jslib-media.git#0.2.2
+    "@whereby/jslib-media" whereby/jslib-media.git#1.3.2
     assert "^2.0.0"
     axios "^1.2.3"
     btoa "^1.2.1"
+    events "^3.3.0"
     heresy "^1.0.4"
 
-"@whereby/jslib-media@github:whereby/jslib-media#0.2.2":
-  version "0.2.2"
-  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/98ad53d8570ee20738763759d2726e7979f8beac"
+"@whereby/jslib-media@whereby/jslib-media.git#1.3.2":
+  version "1.3.2"
+  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/231dd5e11c30e4b601fda0a47543e72f19f6fbf1"
   dependencies:
     assert "^2.0.0"
-    mediasoup-client "^3.6.82"
-    sdp "^3.1.0"
-    socket.io-client "^4.6.1"
-    uuid "^9.0.0"
-    webrtc-adapter "^8.2.0"
+    events "^3.3.0"
+    mediasoup-client "3.6.100"
+    rtcstats "github:lifeonairteam/rtcstats#v3.1.0"
+    sdp "^2.2.0"
+    sdp-transform "^2.14.1"
+    socket.io-client "4.7.2"
+    socket.io-client-legacy "npm:socket.io-client@1.7.4"
+    uuid "^9.0.1"
+    webrtc-adapter "^7.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -2491,6 +2494,11 @@ adjust-sourcemap-loader@^4.0.0:
   dependencies:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
+
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
+  integrity sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==
 
 agent-base@6:
   version "6.0.2"
@@ -2715,6 +2723,11 @@ arraybuffer.prototype.slice@^1.0.2:
     get-intrinsic "^1.2.1"
     is-array-buffer "^3.0.2"
     is-shared-array-buffer "^1.0.2"
+
+arraybuffer.slice@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
+  integrity sha512-6ZjfQaBSy6CuIH0+B0NrxMfDE5VIOCP/5gOqSpEIsaAZx9/giszzrXg6PZ7G51U/n88UmlAgYLNQ9wAnII7PJA==
 
 asap@~2.0.6:
   version "2.0.6"
@@ -2948,15 +2961,32 @@ babel-preset-react-app@^10.0.1:
     babel-plugin-macros "^3.1.0"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
 
+backo2@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+  integrity sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
+
+better-assert@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
+  integrity sha512-bYeph2DFlpK1XmGs6fvlLRUN29QISM3GBuUwSFsMY2XRx4AvC0WNCS57j4c/xGrK2RS24C1w3YoBOsw9fT46tQ==
+  dependencies:
+    callsite "1.0.0"
 
 bfj@^7.0.2:
   version "7.1.0"
@@ -2978,6 +3008,11 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+blob@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
+  integrity sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg==
 
 bluebird@^3.7.2:
   version "3.7.2"
@@ -3093,6 +3128,11 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+callsite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -3314,6 +3354,26 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
+
+component-bind@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
+  integrity sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==
+
+component-emitter@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
+  integrity sha512-YhIbp3PJiznERfjlIkK0ue4obZxt2S60+0W8z24ZymOHT8sHloOqWOqZRU2eN5OlY8U08VFsP02letcu26FilA==
+
+component-emitter@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+  integrity sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -3644,6 +3704,20 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+debug@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  integrity sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==
+  dependencies:
+    ms "0.7.1"
+
+debug@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
+  integrity sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==
+  dependencies:
+    ms "0.7.2"
+
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3966,6 +4040,24 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
+engine.io-client@~1.8.4:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-1.8.6.tgz#d86967c488019524adf2265dba62b886994bd5fd"
+  integrity sha512-6+rInQu8xU7c0fIF6RC4SRKuHVWPt8Xq0bZYS4lMrTwmhRineOlEMsU3X0zS5mHIvCgJsmpOKEX7DhihGk7j0g==
+  dependencies:
+    component-emitter "1.2.1"
+    component-inherit "0.0.3"
+    debug "2.3.3"
+    engine.io-parser "1.3.2"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parsejson "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "~1.1.5"
+    xmlhttprequest-ssl "1.6.3"
+    yeast "0.1.2"
+
 engine.io-client@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.5.2.tgz#8709e22c291d4297ae80318d3c8baeae71f0e002"
@@ -3976,6 +4068,18 @@ engine.io-client@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.11.0"
     xmlhttprequest-ssl "~2.0.0"
+
+engine.io-parser@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-1.3.2.tgz#937b079f0007d0893ec56d46cb220b8cb435220a"
+  integrity sha512-3UyTJo+5Jbmr7rd3MosTAApK7BOIo4sjx8dJYSHa3Em5R3A9Y2s9GWu4JFJe6Px0VieJC0hKUA5NBytC+O7k2A==
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "0.0.6"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.4"
+    has-binary "0.1.7"
+    wtf-8 "1.0.0"
 
 engine.io-parser@~5.2.1:
   version "5.2.1"
@@ -4952,6 +5056,18 @@ has-bigints@^1.0.1, has-bigints@^1.0.2:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
 
+has-binary@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-binary/-/has-binary-0.1.7.tgz#68e61eb16210c9545a0a5cce06a873912fe1e68c"
+  integrity sha512-k1Umb4/jrBWZbtL+QKSji8qWeoZ7ZTkXdnDXt1wxwBKAFM0//u96wDj43mBIqCIas8rDQMYyrBEvcS8hdGd4Sg==
+  dependencies:
+    isarray "0.0.1"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+  integrity sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5213,6 +5329,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+indexof@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+  integrity sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -5509,6 +5630,11 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -6168,6 +6294,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+  integrity sha512-I5YLeauH3rIaE99EE++UeH2M2gSYo8/2TqDac7oZEH6D/DSQ4Woa628Qrfj1X9/OY5Mk5VvIDQaKCDchXaKrmA==
+
 json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -6443,12 +6574,12 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-mediasoup-client@^3.6.82:
-  version "3.6.102"
-  resolved "https://registry.yarnpkg.com/mediasoup-client/-/mediasoup-client-3.6.102.tgz#b0a86699f69d71f9e3bcc0c496a47b05dea6f76d"
-  integrity sha512-C388Deb9OcVxoL+4g+zLHFzv8/OH5KNESQEln8SyKa2Afd28PuTlEtX7xkC22Bxx0xlN5VV7ivYP8+56jhVZMA==
+mediasoup-client@3.6.100:
+  version "3.6.100"
+  resolved "https://registry.yarnpkg.com/mediasoup-client/-/mediasoup-client-3.6.100.tgz#184edf2368665d45ba02c57d2c946919237f7b34"
+  integrity sha512-ZYxJYXDh7TdjK+QHpYuSRG+OTZC8+CI/UkhVUs5P2RSM7iLVOjLrtVemuEEa9Hwqx9HuYPbo+l/meZtFSEqijw==
   dependencies:
-    "@types/debug" "^4.1.10"
+    "@types/debug" "^4.1.8"
     awaitqueue "^3.0.1"
     debug "^4.3.4"
     events "^3.3.0"
@@ -6457,7 +6588,7 @@ mediasoup-client@^3.6.82:
     queue-microtask "^1.2.3"
     sdp-transform "^2.14.1"
     supports-color "^9.4.0"
-    ua-parser-js "^1.0.36"
+    ua-parser-js "^1.0.35"
 
 memfs@^3.1.2, memfs@^3.4.3:
   version "3.6.0"
@@ -6553,6 +6684,16 @@ mkdirp@~0.5.1:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+ms@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+  integrity sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg==
+
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+  integrity sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -6679,6 +6820,11 @@ object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+object-component@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
+  integrity sha512-S0sN3agnVh2SZNEIGc0N1X4Z5K0JeFbGBrnuZpsxuUh5XLF0BnvWkMjRXo/zGKLd/eghvNIKcx1pQkmUjXIyrA==
 
 object-hash@^3.0.0:
   version "3.0.0"
@@ -6833,6 +6979,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
 
+options@>=0.0.5:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
+  integrity sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg==
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -6910,6 +7061,27 @@ parse5@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parsejson@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.3.tgz#ab7e3759f209ece99437973f7d0f1f64ae0e64ab"
+  integrity sha512-v38ZjVbinlZ2r1Rz06WUZEnGoSRcEGX+roMsiWjHeAe23s2qlQUyfmsPQZvh7d8l0E8AZzTIO/RkUr00LfkSiA==
+  dependencies:
+    better-assert "~1.0.0"
+
+parseqs@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
+  integrity sha512-B3Nrjw2aL7aI4TDujOzfA4NsEc4u1lVcIRE0xesutH8kjeWF70uk+W5cBlIQx04zUH9NTBvuN36Y9xLRPK6Jjw==
+  dependencies:
+    better-assert "~1.0.0"
+
+parseuri@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
+  integrity sha512-ijhdxJu6l5Ru12jF0JvzXVPvsC+VibqeaExlNoMhWN6VQ79PGjkmc7oA4W1lp00sFkNyj0fx6ivPLdV51/UMog==
+  dependencies:
+    better-assert "~1.0.0"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -8075,6 +8247,17 @@ rollup@^2.43.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rtcpeerconnection-shim@^1.2.15:
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz#e7cc189a81b435324c4949aa3dfb51888684b243"
+  integrity sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==
+  dependencies:
+    sdp "^2.6.0"
+
+"rtcstats@github:lifeonairteam/rtcstats#v3.1.0":
+  version "3.0.3"
+  resolved "https://codeload.github.com/lifeonairteam/rtcstats/tar.gz/8d46fedd3031ccdc52e7ec8525207e11dbb3115f"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -8190,10 +8373,10 @@ sdp-transform@^2.14.1:
   resolved "https://registry.yarnpkg.com/sdp-transform/-/sdp-transform-2.14.1.tgz#2bb443583d478dee217df4caa284c46b870d5827"
   integrity sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw==
 
-sdp@^3.1.0, sdp@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/sdp/-/sdp-3.2.0.tgz#8961420552b36663b4d13ddba6f478d1461896a5"
-  integrity sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw==
+sdp@^2.12.0, sdp@^2.2.0, sdp@^2.6.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/sdp/-/sdp-2.12.0.tgz#338a106af7560c86e4523f858349680350d53b22"
+  integrity sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw==
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -8340,7 +8523,24 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
-socket.io-client@^4.6.1:
+"socket.io-client-legacy@npm:socket.io-client@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-1.7.4.tgz#ec9f820356ed99ef6d357f0756d648717bdd4281"
+  integrity sha512-vW9xr9XyTJejFS//7GNZmLTLkUSAcvOSxRXXhrojV+7wboTFB8CuvK1UBCW3NiB2kqyi0h9cTeyD7dXjdUd9jQ==
+  dependencies:
+    backo2 "1.0.2"
+    component-bind "1.0.0"
+    component-emitter "1.2.1"
+    debug "2.3.3"
+    engine.io-client "~1.8.4"
+    has-binary "0.1.7"
+    indexof "0.0.1"
+    object-component "0.0.3"
+    parseuri "0.0.5"
+    socket.io-parser "2.3.1"
+    to-array "0.1.4"
+
+socket.io-client@4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.7.2.tgz#f2f13f68058bd4e40f94f2a1541f275157ff2c08"
   integrity sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==
@@ -8349,6 +8549,16 @@ socket.io-client@^4.6.1:
     debug "~4.3.2"
     engine.io-client "~6.5.2"
     socket.io-parser "~4.2.4"
+
+socket.io-parser@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-2.3.1.tgz#dd532025103ce429697326befd64005fcfe5b4a0"
+  integrity sha512-j6l4g/+yWQjmy1yByzg1DPFL4vxQw+NwCJatIxni/AE1wfm17FBtIKSWU4Ay+onrJwDxmC4eK4QS/04ZsqYwZQ==
+  dependencies:
+    component-emitter "1.1.2"
+    debug "2.2.0"
+    isarray "0.0.1"
+    json3 "3.3.2"
 
 socket.io-parser@~4.2.4:
   version "4.2.4"
@@ -8844,6 +9054,11 @@ tmpl@1.0.5:
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
+to-array@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+  integrity sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -9015,7 +9230,7 @@ typescript@^4.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-ua-parser-js@^1.0.36:
+ua-parser-js@^1.0.35:
   version "1.0.36"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.36.tgz#a9ab6b9bd3a8efb90bb0816674b412717b7c428c"
   integrity sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==
@@ -9041,6 +9256,11 @@ uhyphen@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/uhyphen/-/uhyphen-0.1.0.tgz#3cc22afa790daa802b9f6789f3583108d5b4a08c"
   integrity sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==
+
+ultron@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
+  integrity sha512-QMpnpVtYaWEeY+MwKDN/UdKlE/LsFZXM5lO1u7GaZzNgmIbGixHEmVMIKT+vqYOALu3m5GYQy9kz4Xu4IVn7Ow==
 
 umap@^1.0.2:
   version "1.0.2"
@@ -9186,7 +9406,7 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
@@ -9369,12 +9589,13 @@ webpack@^5.64.4:
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
-webrtc-adapter@^8.2.0:
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-8.2.3.tgz#85e5e52ea68e808be8d6db85e338aa5c95e80022"
-  integrity sha512-gnmRz++suzmvxtp3ehQts6s2JtAGPuDPjA1F3a9ckNpG1kYdYuHWYpazoAnL9FS5/B21tKlhkorbdCXat0+4xQ==
+webrtc-adapter@^7.3.0:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz#b2c227a6144983b35057df67bd984a7d4bfd17f1"
+  integrity sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==
   dependencies:
-    sdp "^3.2.0"
+    rtcpeerconnection-shim "^1.2.15"
+    sdp "^2.12.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"
@@ -9697,10 +9918,23 @@ ws@^8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
+ws@~1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
+  integrity sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
 ws@~8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
+wtf-8@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+  integrity sha512-qfR6ovmRRMxNHgUNYI9LRdVofApe/eYrv4ggNOvvCP+pPdEo9Ym93QN4jUceGD6PignBbp2zAzgoE7GibAdq2A==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -9711,6 +9945,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlhttprequest-ssl@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xmlhttprequest-ssl@~2.0.0:
   version "2.0.0"
@@ -9759,6 +9998,11 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+  integrity sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/test/testsuites/connect.spec.ts
+++ b/test/testsuites/connect.spec.ts
@@ -20,6 +20,6 @@ test.describe("unlocked room", () => {
         await joinRoom({ page, roomUrl });
 
         await expect(page.locator("h1")).toContainText(/Room/);
-        await expect(page.locator("dd[data-testid='roomConnectionStatus']")).toContainText("connected");
+        await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("connected");
     });
 });

--- a/test/testsuites/knock.spec.ts
+++ b/test/testsuites/knock.spec.ts
@@ -29,14 +29,14 @@ roomModes.forEach((roomMode) => {
             await joinRoom({ page: guest, roomUrl, expectLockScreen: true });
 
             await guest.getByRole("button", { name: "Knock" }).click();
-            await expect(guest.getByTestId("roomConnectionStatus")).toContainText("knocking");
+            await expect(guest.getByTestId("connectionStatus")).toContainText("knocking");
             await expect(host.getByTestId("knockRequest")).toHaveCount(1);
 
             await host.getByTestId("knockRequest").getByRole("button", { name: "Let in" }).click();
             await expect(host.getByTestId("knockRequest")).toHaveCount(0);
             await expect(host.getByTestId("remoteParticipantVideo")).toHaveCount(1);
 
-            await expect(guest.getByTestId("roomConnectionStatus")).toContainText("connected");
+            await expect(guest.getByTestId("connectionStatus")).toContainText("connected");
             await expect(guest.getByTestId("remoteParticipantVideo")).toHaveCount(1);
         });
 
@@ -45,7 +45,7 @@ roomModes.forEach((roomMode) => {
             await joinRoom({ page: guest, roomUrl, expectLockScreen: true });
 
             await guest.getByRole("button", { name: "Knock" }).click();
-            await expect(guest.getByTestId("roomConnectionStatus")).toContainText("knocking");
+            await expect(guest.getByTestId("connectionStatus")).toContainText("knocking");
 
             const host = page;
             await joinRoom({ page, roomUrl: hostRoomUrl });
@@ -55,7 +55,7 @@ roomModes.forEach((roomMode) => {
             await expect(host.getByTestId("knockRequest")).toHaveCount(0);
             await expect(host.getByTestId("remoteParticipantVideo")).toHaveCount(1);
 
-            await expect(guest.getByTestId("roomConnectionStatus")).toContainText("connected");
+            await expect(guest.getByTestId("connectionStatus")).toContainText("connected");
             await expect(guest.getByTestId("remoteParticipantVideo")).toHaveCount(1);
         });
 
@@ -68,7 +68,7 @@ roomModes.forEach((roomMode) => {
             await joinRoom({ page: guest, roomUrl, expectLockScreen: true });
 
             await guest.getByRole("button", { name: "Knock" }).click();
-            await expect(guest.getByTestId("roomConnectionStatus")).toContainText("knocking");
+            await expect(guest.getByTestId("connectionStatus")).toContainText("knocking");
             await expect(host.getByTestId("knockRequest")).toHaveCount(1);
 
             await host.getByTestId("knockRequest").getByRole("button", { name: "Reject" }).click();
@@ -88,7 +88,7 @@ roomModes.forEach((roomMode) => {
             await joinRoom({ page: guest, roomUrl, expectLockScreen: true });
 
             await guest.getByRole("button", { name: "Knock" }).click();
-            await expect(guest.getByTestId("roomConnectionStatus")).toContainText("knocking");
+            await expect(guest.getByTestId("connectionStatus")).toContainText("knocking");
             await expect(host.getByTestId("knockRequest")).toHaveCount(1);
 
             await guest.close();

--- a/test/testsuites/utils/room.ts
+++ b/test/testsuites/utils/room.ts
@@ -129,7 +129,7 @@ async function joinRoom({
         await expect(page.locator("h1")).toContainText(/Room locked/);
     } else {
         await expect(page.locator("h1")).toContainText(/Room/);
-        await expect(page.locator("dd[data-testid='roomConnectionStatus']")).toContainText("connected");
+        await expect(page.locator("dd[data-testid='connectionStatus']")).toContainText("connected");
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,14 +3825,14 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whereby/jslib-media@whereby/jslib-media.git#1.3.2":
-  version "1.3.2"
-  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/231dd5e11c30e4b601fda0a47543e72f19f6fbf1"
+"@whereby/jslib-media@whereby/jslib-media.git#1.3.3":
+  version "1.3.3"
+  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/1fb844d4b52769a2adb620c26496422e13805d21"
   dependencies:
     assert "^2.0.0"
     events "^3.3.0"
     mediasoup-client "3.6.100"
-    rtcstats "github:lifeonairteam/rtcstats#v3.1.0"
+    rtcstats "github:whereby/rtcstats#v5.3.0"
     sdp "^2.2.0"
     sdp-transform "^2.14.1"
     socket.io-client "4.7.2"
@@ -11300,9 +11300,9 @@ rtcpeerconnection-shim@^1.2.15:
   dependencies:
     sdp "^2.6.0"
 
-"rtcstats@github:lifeonairteam/rtcstats#v3.1.0":
-  version "3.0.3"
-  resolved "https://codeload.github.com/lifeonairteam/rtcstats/tar.gz/8d46fedd3031ccdc52e7ec8525207e11dbb3115f"
+"rtcstats@github:whereby/rtcstats#v5.3.0":
+  version "5.3.0"
+  resolved "https://codeload.github.com/whereby/rtcstats/tar.gz/f696794035acc18a0d42229217a9a3b7630d524e"
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
### Summary

Clean up SDK's api surface before the beta release.

### Changes

* Remove `accepted` state from `roomConnectionStatus`
      > This state is not used for anything, it should be safe to remove.
* Rename `rejected` state to `knock_rejected`
      > Use a more descriptive status name when a knock request gets rejected on a locked room.
* Rename `roomConnectionStatus` -> `connectionStatus`
* Remove `mostRecentChatMessage`
* Remove `startScreenshareError`
* Replace `isStartingScreenshare` with `localScreenshareStatus` and fix the missing state reset when screen share stops
* Make roomConnectionOptions optional
       > Use default localMediaConstraints' audio, video: true.
* Use the default media constraints in the related story
       > `useLocalMedia` already has a default option and the same value was
passed in the story. This commit removes this unnecessary param.
* Do not expose `newJoiner` and `streams` on `remoteParticipant`
       > These are internal props, no need to expose them to in the useRoomConnection's `state`.

### Test plan

knock:
1. Use the sdk with a locked room
2. Join the room with a host key
3. Knock the room with a guest participant
4. Reject the knock with the host => room connection status should be `knock_rejected`

screenshare status:
1. start/stop screenshares and inspect the changes of the state's `localScreenshareStatus`
2. initially it is `undefined`
3. starting a screenshare => `starting`
4. when screenshare is in progress => `active`
5. stop screenshare either by the `stopScreenshare` action or by the browser's native alert => `undefined` again

useRoomConnection's default options:
1. use the sdk's `useRoomConnection` with a roomUrl only, like `useRoomConnection(roomUrl)`
2. it should connect with the default media constraints

`newJoiner` and `streams` props in `remoteParticipant`
1. `console.log` the `state` or `state.remoteParticipants` in your demo app
2. join the room with 2 participants
3. check the logs: `newJoiner` and `streams` props shouldn't be there.

Make sure your demo app works after migrating to this version 😇 .