### PR TITLE
Type custom event payloads

### DIFF
--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -88,6 +88,7 @@ export type ParticipantLeftEvent = {
 export type ParticipantStreamAddedEvent = {
     participantId: string;
     stream: MediaStream;
+    streamId: string;
 };
 
 export type ParticipantAudioEnabledEvent = {
@@ -211,7 +212,13 @@ export function handleStreamAdded(
     }
     // screenshare
     return new RoomEvent("screenshare_started", {
-        detail: { participantId: clientId, stream, id: streamId, isLocal: false },
+        detail: {
+            participantId: clientId,
+            stream,
+            id: streamId,
+            isLocal: false,
+            hasAudioTrack: stream.getAudioTracks().length > 0,
+        },
     });
 }
 
@@ -966,7 +973,9 @@ export default class RoomConnection extends TypedEventTarget {
 
             this.rtcManager?.removeStream(id, this.localMedia.screenshareStream, null);
             this.screenshares = this.screenshares.filter((s) => s.id !== id);
-            this.dispatchEvent(new RoomEvent("screenshare_stopped", { detail: { participantId: this.selfId, id } }));
+            this.dispatchEvent(
+                new RoomEvent("screenshare_stopped", { detail: { participantId: this.selfId || "", id } })
+            );
             this.localMedia.stopScreenshare();
         }
     }

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -157,6 +157,17 @@ export interface RoomEventsMap {
     waiting_participant_left: (e: CustomEvent<WaitingParticipantLeftEvent>) => void;
 }
 
+type ArgType<T> = T extends (arg: infer U) => unknown ? U : never;
+type RoomEventKey = keyof RoomEventsMap;
+type RoomEventHandler<T extends RoomEventKey> = RoomEventsMap[T];
+type RoomEventType<T extends RoomEventKey> = ArgType<RoomEventHandler<T>>;
+type RoomEventPayload<T extends RoomEventKey> = RoomEventType<T> extends CustomEvent<infer U> ? U : never;
+class RoomEvent<T extends RoomEventKey> extends CustomEvent<RoomEventPayload<T>> {
+    constructor(eventType: T, eventInitDict?: CustomEventInit<RoomEventPayload<T>>) {
+        super(eventType, eventInitDict);
+    }
+}
+
 const API_BASE_URL = process.env["REACT_APP_API_BASE_URL"] || "https://api.whereby.dev";
 const SIGNAL_BASE_URL = process.env["REACT_APP_SIGNAL_BASE_URL"] || "wss://signal.appearin.net";
 
@@ -196,10 +207,10 @@ export function handleStreamAdded(
         (!remoteParticipant.stream && streamType === "webcam") ||
         (!remoteParticipant.stream && !streamType && remoteParticipant.streams.indexOf(remoteParticipantStream) < 1)
     ) {
-        return new CustomEvent("participant_stream_added", { detail: { participantId: clientId, stream, streamId } });
+        return new RoomEvent("participant_stream_added", { detail: { participantId: clientId, stream, streamId } });
     }
     // screenshare
-    return new CustomEvent("screenshare_started", {
+    return new RoomEvent("screenshare_started", {
         detail: { participantId: clientId, stream, id: streamId, isLocal: false },
     });
 }
@@ -345,12 +356,12 @@ export default class RoomConnection extends TypedEventTarget {
         this.localMedia.addEventListener("camera_enabled", (e) => {
             const { enabled } = e.detail;
             this.signalSocket.emit("enable_video", { enabled });
-            this.dispatchEvent(new CustomEvent("local_camera_enabled", { detail: { enabled } }));
+            this.dispatchEvent(new RoomEvent("local_camera_enabled", { detail: { enabled } }));
         });
         this.localMedia.addEventListener("microphone_enabled", (e) => {
             const { enabled } = e.detail;
             this.signalSocket.emit("enable_audio", { enabled });
-            this.dispatchEvent(new CustomEvent("local_microphone_enabled", { detail: { enabled } }));
+            this.dispatchEvent(new RoomEvent("local_microphone_enabled", { detail: { enabled } }));
         });
 
         const webrtcProvider = {
@@ -385,12 +396,12 @@ export default class RoomConnection extends TypedEventTarget {
     }
 
     private _handleNewChatMessage(message: SignalChatMessage) {
-        this.dispatchEvent(new CustomEvent("chat_message", { detail: message }));
+        this.dispatchEvent(new RoomEvent("chat_message", { detail: message }));
     }
 
     private _handleCloudRecordingStarted({ client }: { client: SignalClient }) {
         this.dispatchEvent(
-            new CustomEvent("cloud_recording_started", {
+            new RoomEvent("cloud_recording_started", {
                 detail: {
                     status: "recording",
                     startedAt: client.startedCloudRecordingAt
@@ -403,7 +414,7 @@ export default class RoomConnection extends TypedEventTarget {
 
     private _handleStreamingStarted() {
         this.dispatchEvent(
-            new CustomEvent("streaming_started", {
+            new RoomEvent("streaming_started", {
                 detail: {
                     status: "streaming",
                     // We don't have the streaming start time stored on the
@@ -430,7 +441,7 @@ export default class RoomConnection extends TypedEventTarget {
         this.remoteParticipants = [...this.remoteParticipants, remoteParticipant];
         this._handleAcceptStreams([remoteParticipant]);
         this.dispatchEvent(
-            new CustomEvent("participant_joined", {
+            new RoomEvent("participant_joined", {
                 detail: { remoteParticipant },
             })
         );
@@ -442,7 +453,7 @@ export default class RoomConnection extends TypedEventTarget {
         if (!remoteParticipant) {
             return;
         }
-        this.dispatchEvent(new CustomEvent("participant_left", { detail: { participantId: remoteParticipant.id } }));
+        this.dispatchEvent(new RoomEvent("participant_left", { detail: { participantId: remoteParticipant.id } }));
     }
 
     private _handleClientAudioEnabled({ clientId, isAudioEnabled }: { clientId: string; isAudioEnabled: boolean }) {
@@ -451,7 +462,7 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
         this.dispatchEvent(
-            new CustomEvent("participant_audio_enabled", {
+            new RoomEvent("participant_audio_enabled", {
                 detail: { participantId: remoteParticipant.id, isAudioEnabled },
             })
         );
@@ -463,7 +474,7 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
         this.dispatchEvent(
-            new CustomEvent("participant_video_enabled", {
+            new RoomEvent("participant_video_enabled", {
                 detail: { participantId: remoteParticipant.id, isVideoEnabled },
             })
         );
@@ -475,7 +486,7 @@ export default class RoomConnection extends TypedEventTarget {
             return;
         }
         this.dispatchEvent(
-            new CustomEvent("participant_metadata_changed", {
+            new RoomEvent("participant_metadata_changed", {
                 detail: { participantId: remoteParticipant.id, displayName },
             })
         );
@@ -496,7 +507,7 @@ export default class RoomConnection extends TypedEventTarget {
             this.connectionStatus = "knock_rejected";
 
             this.dispatchEvent(
-                new CustomEvent("connection_status_changed", {
+                new RoomEvent("connection_status_changed", {
                     detail: {
                         connectionStatus: this.connectionStatus,
                     },
@@ -509,7 +520,7 @@ export default class RoomConnection extends TypedEventTarget {
         const { clientId } = payload;
 
         this.dispatchEvent(
-            new CustomEvent("waiting_participant_left", {
+            new RoomEvent("waiting_participant_left", {
                 detail: { participantId: clientId },
             })
         );
@@ -521,7 +532,7 @@ export default class RoomConnection extends TypedEventTarget {
         if (error === "room_locked" && isLocked) {
             this.connectionStatus = "room_locked";
             this.dispatchEvent(
-                new CustomEvent("connection_status_changed", {
+                new RoomEvent("connection_status_changed", {
                     detail: {
                         connectionStatus: this.connectionStatus,
                     },
@@ -560,8 +571,9 @@ export default class RoomConnection extends TypedEventTarget {
                 .map((c) => new RemoteParticipant({ ...c, newJoiner: false }));
 
             this.connectionStatus = "connected";
+
             this.dispatchEvent(
-                new CustomEvent("room_joined", {
+                new RoomEvent("room_joined", {
                     detail: {
                         localParticipant: this.localParticipant,
                         remoteParticipants: this.remoteParticipants,
@@ -578,7 +590,7 @@ export default class RoomConnection extends TypedEventTarget {
         const { clientId, displayName } = event;
 
         this.dispatchEvent(
-            new CustomEvent("waiting_participant_joined", {
+            new RoomEvent("waiting_participant_joined", {
                 detail: { participantId: clientId, displayName },
             })
         );
@@ -596,7 +608,7 @@ export default class RoomConnection extends TypedEventTarget {
     private _handleDisconnect() {
         this.connectionStatus = "disconnected";
         this.dispatchEvent(
-            new CustomEvent("connection_status_changed", {
+            new RoomEvent("connection_status_changed", {
                 detail: {
                     connectionStatus: this.connectionStatus,
                 },
@@ -605,11 +617,11 @@ export default class RoomConnection extends TypedEventTarget {
     }
 
     private _handleCloudRecordingStopped() {
-        this.dispatchEvent(new CustomEvent("cloud_recording_stopped"));
+        this.dispatchEvent(new RoomEvent("cloud_recording_stopped"));
     }
 
     private _handleStreamingStopped() {
-        this.dispatchEvent(new CustomEvent("streaming_stopped"));
+        this.dispatchEvent(new RoomEvent("streaming_stopped"));
     }
 
     private _handleScreenshareStarted(screenshare: SignalScreenshareStartedEvent) {
@@ -647,7 +659,7 @@ export default class RoomConnection extends TypedEventTarget {
 
         remoteParticipant.removeStream(id);
         this.screenshares = this.screenshares.filter((s) => !(s.participantId === participantId && s.id === id));
-        this.dispatchEvent(new CustomEvent("screenshare_stopped", { detail: { participantId, id } }));
+        this.dispatchEvent(new RoomEvent("screenshare_stopped", { detail: { participantId, id } }));
     }
 
     private _handleRtcEvent<K extends keyof RtcEvents>(eventName: K, data: RtcEvents[K]) {
@@ -792,7 +804,7 @@ export default class RoomConnection extends TypedEventTarget {
         this.signalSocket.connect();
         this.connectionStatus = "connecting";
         this.dispatchEvent(
-            new CustomEvent("connection_status_changed", {
+            new RoomEvent("connection_status_changed", {
                 detail: {
                     connectionStatus: this.connectionStatus,
                 },
@@ -823,7 +835,7 @@ export default class RoomConnection extends TypedEventTarget {
     public knock() {
         this.connectionStatus = "knocking";
         this.dispatchEvent(
-            new CustomEvent("connection_status_changed", {
+            new RoomEvent("connection_status_changed", {
                 detail: {
                     connectionStatus: this.connectionStatus,
                 },
@@ -937,7 +949,7 @@ export default class RoomConnection extends TypedEventTarget {
         ];
 
         this.dispatchEvent(
-            new CustomEvent("screenshare_started", {
+            new RoomEvent("screenshare_started", {
                 detail: {
                     participantId: this.selfId || "",
                     id: screenshareStream.id,
@@ -954,7 +966,7 @@ export default class RoomConnection extends TypedEventTarget {
 
             this.rtcManager?.removeStream(id, this.localMedia.screenshareStream, null);
             this.screenshares = this.screenshares.filter((s) => s.id !== id);
-            this.dispatchEvent(new CustomEvent("screenshare_stopped", { detail: { participantId: this.selfId, id } }));
+            this.dispatchEvent(new RoomEvent("screenshare_stopped", { detail: { participantId: this.selfId, id } }));
             this.localMedia.stopScreenshare();
         }
     }

--- a/src/lib/__tests__/RoomConnection.spec.ts
+++ b/src/lib/__tests__/RoomConnection.spec.ts
@@ -99,6 +99,12 @@ describe("handleStreamAdded", () => {
         });
 
         expect(res?.type).toEqual("screenshare_started");
-        expect(res?.detail).toEqual({ participantId: clientId, stream, id: streamId, isLocal: false });
+        expect(res?.detail).toEqual({
+            participantId: clientId,
+            stream,
+            id: streamId,
+            isLocal: false,
+            hasAudioTrack: false,
+        });
     });
 });


### PR DESCRIPTION
Adds a thing custom event wrapper that ensures our events align with what we define in RoomEventsMap and LocalMediaEventsMap

### To test
- I guess if it compiles and the test apps still work we're golden?

### Gotchas
relies on us using `RoomEvent`|`LocalMediaEvent`, so if someone comes along and adds another handler using `CustomEvent` we lose the typings...

We _could_ add a `this._dispatchRoomEvent(e: RoomEvent)` function to the class to solve this maybe?
But then someone could just use `this.dispatchEvent(e)` to get around that... 

Maybe it's not a big deal