### PR TITLE
Avoid video resizing

### DIFF
--- a/src/lib/react/VideoView.tsx
+++ b/src/lib/react/VideoView.tsx
@@ -64,7 +64,7 @@ export default ({ muted, mirror = false, stream, onResize, ...rest }: VideoViewP
             autoPlay
             playsInline
             {...rest}
-            style={{ transform: mirror ? "scaleX(-1)" : "none", ...rest.style }}
+            style={{ transform: mirror ? "scaleX(-1)" : "none", width: "100%", height: "100%", ...rest.style }}
         />
     );
 };


### PR DESCRIPTION
Set the default width and height of the `VideoView` component to 100%, so that we avoid the random resizing when the SFU auto-adjust the resolution. This leaves it up to the consumers to set a size on the parent.

#### Tested like:
Join with two participants in your test app, avoid putting any styles on the parent of the video views.
The videos should take up all available space, and not resize "randomly". 
Verify that you can override the height and width properties on the `style` prop directly on the VideoView component