### PR TITLE
bind this to message event listener

### DIFF
--- a/src/lib/embed/index.ts
+++ b/src/lib/embed/index.ts
@@ -63,10 +63,10 @@ define("WherebyEmbed", {
         this.iframe = ref();
     },
     onconnected() {
-        window.addEventListener("message", this.onmessage);
+        window.addEventListener("message", this.onmessage.bind(this));
     },
     ondisconnected() {
-        window.removeEventListener("message", this.onmessage);
+        window.removeEventListener("message", this.onmessage.bind(this));
     },
     observedAttributes: [
         "displayName",
@@ -120,7 +120,7 @@ define("WherebyEmbed", {
         this._postCommand("toggle_screenshare", [enabled]);
     },
     onmessage({ origin, data }: { origin: string; data: { type: string; payload: string } }) {
-        if (origin !== this.url?.origin) return;
+        if (origin !== this.url.origin) return;
         const { type, payload: detail } = data;
         this.dispatchEvent(new CustomEvent(type, { detail }));
     },


### PR DESCRIPTION
`this` in onmessage was bound to the parent context, so events were never
being forwarded from the iframe, as the `this.url.origin` was always
undefined.

Removes the need for the null coalesce in `this.url?.origin` as there
will be no events triggered before this property is set in `render`

## to test
1. add current beta1 to some test project, render the iframe element
2. `document.querySelector("whereby-embed").addEventListener("camera-toggle", () => console.log("Triggered"))`
3. toggle camera a few times and see there are no messages
4. replace current beta1 with this branch
5. step 2 & 3
6. see the messages are received

## gotchas

I tried adding a test for this (since we didn't detect this regression when it happened), but the PWA requirement to accept cam/mic permissions means it won't work in CI