### PR TITLE
Add actions to start, stop cloud recording

### DIFF
--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -58,8 +58,8 @@ export type ConnectionStatus =
     | "knock_rejected";
 
 export type CloudRecordingState = {
-    status: "recording";
-    startedAt: number;
+    status: "recording" | "requested";
+    startedAt?: number;
 };
 
 export type LiveStreamState = {
@@ -138,6 +138,7 @@ export type LocalMicrophoneEnabledEvent = {
 
 export interface RoomEventsMap {
     chat_message: (e: CustomEvent<ChatMessage>) => void;
+    cloud_recording_request_started: (e: CustomEvent<CloudRecordingState>) => void;
     cloud_recording_started: (e: CustomEvent<CloudRecordingState>) => void;
     cloud_recording_stopped: (e: CustomEvent<CloudRecordingState>) => void;
     local_camera_enabled: (e: CustomEvent<LocalCameraEnabledEvent>) => void;
@@ -971,6 +972,7 @@ export default class RoomConnection extends TypedEventTarget {
             })
         );
     }
+
     public stopScreenshare() {
         if (this.localMedia.screenshareStream) {
             const { id } = this.localMedia.screenshareStream;
@@ -982,5 +984,16 @@ export default class RoomConnection extends TypedEventTarget {
             );
             this.localMedia.stopScreenshare();
         }
+    }
+
+    public startCloudRecording() {
+        this.signalSocket.emit("start_recording", {
+            recording: "cloud",
+        });
+        this.dispatchEvent(new RoomConnectionEvent("cloud_recording_request_started"));
+    }
+
+    public stopCloudRecording() {
+        this.signalSocket.emit("stop_recording");
     }
 }

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -59,6 +59,9 @@ type RoomConnectionEvent =
           payload: CloudRecordingState;
       }
     | {
+          type: "CLOUD_RECORDING_REQUEST_STARTED";
+      }
+    | {
           type: "CLOUD_RECORDING_STOPPED";
       }
     | {
@@ -225,6 +228,13 @@ function reducer(state: RoomConnectionState, action: RoomConnectionEvent): RoomC
                 ...state,
                 chatMessages: [...state.chatMessages, action.payload],
             };
+        case "CLOUD_RECORDING_REQUEST_STARTED":
+            return {
+                ...state,
+                cloudRecording: {
+                    status: "requested",
+                },
+            };
         case "CLOUD_RECORDING_STARTED":
             return {
                 ...state,
@@ -389,7 +399,9 @@ interface RoomConnectionActions {
     toggleMicrophone(enabled?: boolean): void;
     acceptWaitingParticipant(participantId: string): void;
     rejectWaitingParticipant(participantId: string): void;
+    startCloudRecording(): void;
     startScreenshare(): void;
+    stopCloudRecording(): void;
     stopScreenshare(): void;
 }
 
@@ -448,6 +460,9 @@ export function useRoomConnection(
         (): EventListener<keyof RoomEventsMap>[] => [
             createEventListener("chat_message", (e) => {
                 dispatch({ type: "CHAT_MESSAGE", payload: e.detail });
+            }),
+            createEventListener("cloud_recording_request_started", () => {
+                dispatch({ type: "CLOUD_RECORDING_REQUEST_STARTED" });
             }),
             createEventListener("cloud_recording_started", (e) => {
                 const { status, startedAt } = e.detail;
@@ -595,6 +610,12 @@ export function useRoomConnection(
             },
             rejectWaitingParticipant: (participantId) => {
                 roomConnection.rejectWaitingParticipant(participantId);
+            },
+            startCloudRecording: () => {
+                roomConnection.startCloudRecording();
+            },
+            stopCloudRecording: () => {
+                roomConnection.stopCloudRecording();
             },
             startScreenshare: async () => {
                 dispatch({ type: "LOCAL_SCREENSHARE_STARTING" });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -256,6 +256,8 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         knock_room: KnockRoomRequest;
         leave_room: void;
         send_client_metadata: { type: string; payload: { displayName?: string } };
+        start_recording: { recording: string };
+        stop_recording: void;
     }
 
     export default class ServerSocket {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -139,6 +139,11 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         userId: string;
     }
 
+    interface CloudRecordingStartedEvent {
+        error?: string;
+        startedAt?: string;
+    }
+
     interface ClientLeftEvent {
         clientId: string;
     }
@@ -207,6 +212,7 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         chat_message: ChatMessage;
         client_left: ClientLeftEvent;
         client_metadata_received: ClientMetadataReceivedEvent;
+        cloud_recording_started: CloudRecordingStartedEvent;
         cloud_recording_stopped: void;
         chat_message: ChatMessage;
         connect: void;


### PR DESCRIPTION
* Add cloud recording start/stop actions. NB: only hosts can start/stop cloud recordings.
* Handle cloud recording errors
    * Do not allow to start recording when it is already in progress or requested.
    * Introduce an error state in the CloudRecordingState, so clients can see the reason why their start recording request failed. For example when the UI renders the start recording button for a guest client who has no permission to control recordings.

### Test plan

1. Use this version in your demo app
2. Use the `startCloudRecording` and `stopCloudRecording` buttons to start/stop recordings with the host
