### PR TITLE
Remove the `assert` lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     },
     "dependencies": {
         "@swc/helpers": "^0.3.13",
-        "@whereby/jslib-media": "whereby/jslib-media.git#1.3.6",
+        "@whereby/jslib-media": "whereby/jslib-media.git#1.4.1",
         "assert": "^2.0.0",
         "axios": "^1.2.3",
         "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "dependencies": {
         "@swc/helpers": "^0.3.13",
         "@whereby/jslib-media": "whereby/jslib-media.git#1.4.1",
-        "assert": "^2.0.0",
         "axios": "^1.2.3",
         "btoa": "^1.2.1",
         "events": "^3.3.0",

--- a/src/lib/api/ApiClient.ts
+++ b/src/lib/api/ApiClient.ts
@@ -1,5 +1,5 @@
-import assert from "assert";
 import nodeBtoa from "btoa";
+import assert from "@whereby/jslib-media/src/utils/assert";
 import HttpClient, { HttpClientRequestConfig } from "./HttpClient";
 import MultipartHttpClient from "./MultipartHttpClient";
 import { assertString } from "./parameterAssertUtils";
@@ -92,7 +92,7 @@ export default class ApiClient {
      */
     request(url: string, options: HttpClientRequestConfig): Promise<Response> {
         assertString(url, "url");
-        assert.equal(url[0], "/", 'url<String> only accepts relative URLs beginning with "/".');
+        assert.ok(url[0] === "/", 'url<String> only accepts relative URLs beginning with "/".');
         assert.ok(options, "options are required");
 
         return this.authenticatedHttpClient.request(url, options);
@@ -103,7 +103,7 @@ export default class ApiClient {
      */
     requestMultipart(url: string, options: HttpClientRequestConfig): Promise<Response> {
         assertString(url, "url");
-        assert.equal(url[0], "/", 'url<String> only accepts relative URLs beginning with "/".');
+        assert.ok(url[0] === "/", 'url<String> only accepts relative URLs beginning with "/".');
         assert.ok(options, "options are required");
 
         return this.authenticatedFormDataHttpClient.request(url, options);

--- a/src/lib/api/ApiClient.ts
+++ b/src/lib/api/ApiClient.ts
@@ -74,9 +74,6 @@ export default class ApiClient {
         baseUrl = "https://api.appearin.net",
         fetchDeviceCredentials = noCredentials,
     }: ApiClientOptions = {}) {
-        assertString(baseUrl, "baseUrl");
-        assert.ok(typeof fetchDeviceCredentials === "function", "fetchDeviceCredentials<Function> is required");
-
         this.authenticatedHttpClient = new AuthenticatedHttpClient({
             httpClient: new HttpClient({
                 baseUrl,

--- a/src/lib/api/HttpClient.ts
+++ b/src/lib/api/HttpClient.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import Response, { ErrorResponseObject } from "./Response";
 import { assertString } from "./parameterAssertUtils";
@@ -50,7 +50,7 @@ export default class HttpClient implements IHttpClient {
      */
     request(url: string, options: HttpClientRequestConfig): Promise<Response> {
         assertString(url, "url");
-        assert.equal(url[0], "/", 'url<String> only accepts relative URLs beginning with "/".');
+        assert.ok(url[0] === "/", 'url<String> only accepts relative URLs beginning with "/".');
         assert.ok(options, "options are required");
 
         return this._requestAxios(url, options)

--- a/src/lib/api/HttpClient.ts
+++ b/src/lib/api/HttpClient.ts
@@ -10,7 +10,6 @@ export interface IHttpClient {
 }
 
 function _getAbsoluteUrl({ baseUrl, url }: { baseUrl?: string; url: string }): string {
-    assert.ok(typeof url === "string", "url<String> is required");
     return baseUrl ? baseUrl + url : url;
 }
 

--- a/src/lib/api/MultipartHttpClient.ts
+++ b/src/lib/api/MultipartHttpClient.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 import { HttpClientRequestConfig, IHttpClient } from "./HttpClient";
 import Response from "./Response";
 

--- a/src/lib/api/OrganizationApiClient.ts
+++ b/src/lib/api/OrganizationApiClient.ts
@@ -1,5 +1,5 @@
+import assert from "@whereby/jslib-media/src/utils/assert";
 import ApiClient from "./ApiClient";
-import assert from "assert";
 import { assertString } from "./parameterAssertUtils";
 import { HttpClientRequestConfig } from "./HttpClient";
 import Response from "./Response";
@@ -41,7 +41,7 @@ export default class OrganizationApiClient {
         options: HttpClientRequestConfig
     ): Promise<Response> {
         assertString(url, "url");
-        assert.equal(url[0], "/", 'url<String> only accepts relative URLs beginning with "/".');
+        assert.ok(url[0] === "/", 'url<String> only accepts relative URLs beginning with "/".');
         assert.ok(options, "options are required");
         return this._fetchOrganization().then((organization) => {
             if (!organization) {

--- a/src/lib/api/OrganizationApiClient.ts
+++ b/src/lib/api/OrganizationApiClient.ts
@@ -18,8 +18,9 @@ export default class OrganizationApiClient {
     /**
      * Create an OrganizationApiClient instance.
      *
-     * @param {ApiClient} [apiClient] - The apiClient to use.
-     * @param {Function} [fetchOrganization] - function that returns a promise with the organization.
+     * @param {Object} options - The options for the OrganizationApiClient.
+     * @param {ApiClient} [options.apiClient] - The apiClient to use.
+     * @param {Function} [options.fetchOrganization] - function that returns a promise with the organization.
      */
     constructor({
         apiClient,
@@ -29,8 +30,6 @@ export default class OrganizationApiClient {
         fetchOrganization?: FetchOrganizationFunction;
     }) {
         this._apiClient = apiClient;
-        assert.ok(typeof fetchOrganization === "function", "fetchOrganization<Function> is required");
-
         this._fetchOrganization = fetchOrganization;
         this._apiClient = apiClient;
     }

--- a/src/lib/api/models/Room.ts
+++ b/src/lib/api/models/Room.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 
 export default class Room {
     public readonly isLocked: boolean;

--- a/src/lib/api/organizationService/index.ts
+++ b/src/lib/api/organizationService/index.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 import Organization, { OrganizationPreferences } from "../models/Organization";
 import {
     assertInstanceOf,

--- a/src/lib/api/parameterAssertUtils.ts
+++ b/src/lib/api/parameterAssertUtils.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 
 /**
  * Asserts that value is truthy.
@@ -65,7 +65,7 @@ export function assertInstanceOf<T>(value: unknown, type: new (any: unknown) => 
  */
 export function assertRoomName(roomName: unknown, parameterName = "roomName"): string {
     assertString(roomName, parameterName);
-    assert.equal(typeof roomName === "string" && roomName[0], "/", `${parameterName} must begin with a '/'`);
+    assert.ok(typeof roomName === "string" && roomName[0] === "/", `${parameterName} must begin with a '/'`);
     return roomName as string;
 }
 

--- a/src/lib/api/test/ApiClient.spec.ts
+++ b/src/lib/api/test/ApiClient.spec.ts
@@ -16,11 +16,6 @@ describe("ApiClient", () => {
         it("should not throw an error if no constructor params are passed through", () => {
             expect(() => new ApiClient()).not.toThrowError();
         });
-
-        //@ts-expect-error
-        itShouldThrowIfInvalid("baseUrl", () => new ApiClient({ baseUrl: null }));
-        //@ts-expect-error
-        itShouldThrowIfInvalid("fetchDeviceCredentials", () => new ApiClient({ fetchDeviceCredentials: null }));
     });
 
     describe("request", () => {
@@ -47,9 +42,6 @@ describe("ApiClient", () => {
         it('should throw if `url` does not begin with a "/"', () => {
             expect(() => apiClient.request("some-url", {})).toThrowError();
         });
-
-        //@ts-expect-error
-        itShouldThrowIfInvalid("fetchDeviceCredentials", () => new ApiClient({ fetchDeviceCredentials: null }));
 
         it("should run `this.fetchDeviceCredentials`", () => {
             const url = "/some/path";

--- a/src/lib/api/test/extractUtils.spec.ts
+++ b/src/lib/api/test/extractUtils.spec.ts
@@ -13,7 +13,7 @@ import {
     nullOrTransform,
     Transformer,
 } from "../extractUtils";
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 import { Json } from "../Response";
 import { assertString } from "../parameterAssertUtils";
 type User = { name: string; eyeColor: string | null; age: number; dob: Date };

--- a/src/lib/api/test/parameterAssertUtils.spec.ts
+++ b/src/lib/api/test/parameterAssertUtils.spec.ts
@@ -1,4 +1,3 @@
-import assert from "@whereby/jslib-media/src/utils/assert";
 import {
     assertBoolean,
     assertRoomName,
@@ -13,8 +12,6 @@ function forEachObject(object: Record<string, unknown>, func: (value: unknown, k
 }
 describe("parameterAssertUtils", () => {
     function itShouldThrowForValues(testValues: Record<string, unknown>, test: (desc: string, value: unknown) => void) {
-        assert.ok(typeof test === "function", "test must be a function");
-
         forEachObject(testValues, (value, descriptionOfValue) => {
             it(`should throw for ${descriptionOfValue}`, () => {
                 test(descriptionOfValue, value);

--- a/src/lib/api/test/parameterAssertUtils.spec.ts
+++ b/src/lib/api/test/parameterAssertUtils.spec.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 import {
     assertBoolean,
     assertRoomName,

--- a/src/lib/utils/__tests__/debounce.spec.ts
+++ b/src/lib/utils/__tests__/debounce.spec.ts
@@ -16,13 +16,6 @@ describe("debounce", () => {
         jest.clearAllMocks();
     });
 
-    it("should throw if no function is provided", () => {
-        expect(() => {
-            // @ts-expect-error
-            debounce();
-        }).toThrow("fn<function> is required");
-    });
-
     it("should set the timer with the specified delay", () => {
         const delay = Math.floor(Math.random() * 2000);
 

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "@whereby/jslib-media/src/utils/assert";
 
 interface Options {
     delay?: number;

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,5 +1,3 @@
-import assert from "@whereby/jslib-media/src/utils/assert";
-
 interface Options {
     delay?: number;
     edges?: boolean;
@@ -21,8 +19,6 @@ interface DebouncedFunction {
  * @returns {Function} Debounced function.
  */
 export default function debounce(fn: DebouncedFunction, { delay = 500, edges }: Options = {}): DebouncedFunction {
-    assert.ok(typeof fn === "function", "fn<function> is required");
-
     let timeout: NodeJS.Timeout | undefined;
     let nCalls = 0;
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -82,6 +82,16 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManager" {
     }
 }
 
+declare const assert: {
+    (value: unknown, message?: string | Error): asserts value;
+    ok(value: unknown, message?: string | Error): asserts value;
+    notEqual<T>(actual: T, expected: T, message: string): void;
+};
+
+declare module "@whereby/jslib-media/src/utils/assert" {
+    export = assert;
+}
+
 declare module "@whereby/jslib-media/src/utils/urls" {
     export function fromLocation({ host }: { host: string }): { subdomain: string };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,11 +3581,10 @@
     "@webassemblyjs/ast" "1.11.6"
     "@xtuc/long" "4.2.2"
 
-"@whereby/jslib-media@whereby/jslib-media.git#1.3.6":
-  version "1.3.6"
-  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/bc8f3efd48e9e5b23b886bc8ea181b33f1d62719"
+"@whereby/jslib-media@whereby/jslib-media.git#1.4.1":
+  version "1.4.1"
+  resolved "https://codeload.github.com/whereby/jslib-media/tar.gz/abc55b7e2d3af9c71cb3f3a2953291bb79725064"
   dependencies:
-    assert "^2.0.0"
     events "^3.3.0"
     mediasoup-client "3.6.100"
     rtcstats "github:whereby/rtcstats#v5.3.0"


### PR DESCRIPTION
* Bump jslib-media, the new version:
    * Adds media device and constraints helpers
    * Replaces the 3rd party `assert` lib
* Import `assert` from jslib-media and remove the [assert](https://www.npmjs.com/package/assert) lib from browser-sdk's dependencies.
* Remove some of the redundant type checks.

The `assert` lib replacement should fix the "Could not find module in path: 'assert/assert.js'" error in CodeSandbox.

### Test plan

1. Install the new browser-sdk with different bundlers/frameworks (cra, vite, etc)
2. Make sure you don't get the "Could not find module" error for `assert`.

### Related PR

https://github.com/whereby/jslib-media/pull/32