### PR TITLE
Make use of media constraints helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-beta1",
+    "version": "2.0.0-beta2",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -34,13 +34,13 @@ import ServerSocket, {
     ScreenshareStoppedEvent as SignalScreenshareStoppedEvent,
 } from "@whereby/jslib-media/src/utils/ServerSocket";
 import { sdkVersion } from "./version";
-import LocalMedia from "./LocalMedia";
+import LocalMedia, { LocalMediaOptions } from "./LocalMedia";
 
 type Logger = Pick<Console, "debug" | "error" | "log" | "warn">;
 
 export interface RoomConnectionOptions {
     displayName?: string; // Might not be needed at all
-    localMediaConstraints?: MediaStreamConstraints;
+    localMediaOptions?: LocalMediaOptions;
     roomKey?: string;
     logger?: Logger;
     localMedia?: LocalMedia;
@@ -292,7 +292,14 @@ export default class RoomConnection extends TypedEventTarget {
 
     constructor(
         roomUrl: string,
-        { displayName, localMedia, localMediaConstraints, logger, roomKey, externalId }: RoomConnectionOptions
+        {
+            displayName,
+            localMedia,
+            localMediaOptions: localMediaConstraints,
+            logger,
+            roomKey,
+            externalId,
+        }: RoomConnectionOptions
     ) {
         super();
         this.organizationId = "";

--- a/src/lib/__mocks__/mediaDevices.ts
+++ b/src/lib/__mocks__/mediaDevices.ts
@@ -1,8 +1,23 @@
 import MockMediaStream from "./MediaStream";
 
+const devices = [
+    {
+        deviceId: "audioDeviceId",
+        kind: "audioinput",
+        groupId: "a",
+        label: "Microphone",
+    },
+    {
+        deviceId: "videoDeviceId",
+        kind: "videoinput",
+        groupId: "b",
+        label: "Camera",
+    },
+];
+
 const mockMediaDevices = {
     addEventListener: jest.fn(),
-    enumerateDevices: jest.fn().mockResolvedValue([]),
+    enumerateDevices: jest.fn().mockResolvedValue(devices),
     getUserMedia: jest.fn().mockResolvedValue(new MockMediaStream()),
 };
 

--- a/src/lib/__tests__/LocalMedia.spec.ts
+++ b/src/lib/__tests__/LocalMedia.spec.ts
@@ -1,10 +1,14 @@
 import { jest } from "@jest/globals";
 
-import LocalMedia from "../LocalMedia";
+import LocalMedia, { LocalMediaOptions } from "../LocalMedia";
 import MockRtcManager from "../__mocks__/RtcManager";
 import MockMediaStream from "../__mocks__/MediaStream";
 import MockMediaStreamTrack from "../__mocks__/MediaStreamTrack";
 import mockMediaDevices from "../__mocks__/mediaDevices";
+import { getStream } from "@whereby/jslib-media/src/webrtc/MediaDevices";
+
+jest.mock("@whereby/jslib-media/src/webrtc/MediaDevices");
+const mockedGetStream = jest.mocked(getStream);
 
 Object.defineProperty(window, "MediaStream", {
     writable: true,
@@ -62,89 +66,36 @@ describe("LocalMedia", () => {
 
     describe("instance", () => {
         let localMedia: LocalMedia;
-        let mediaConstraints: MediaStreamConstraints;
+        let localMediaOptions: LocalMediaOptions;
 
         beforeEach(() => {
-            mediaConstraints = { audio: true, video: true };
-            localMedia = new LocalMedia(mediaConstraints);
-        });
-
-        describe("addRtcManager()", () => {
-            it("should add the supplied manager to its list of managers", () => {
-                const rtcManager = new MockRtcManager();
-
-                localMedia.addRtcManager(rtcManager);
-
-                expect(localMedia._rtcManagers).toEqual([rtcManager]);
-            });
-        });
-
-        describe("removeRtcManager()", () => {
-            it("should remove the supplied manager from its list of managers", () => {
-                const rtcManager = new MockRtcManager();
-
-                localMedia.addRtcManager(rtcManager);
-                localMedia.removeRtcManager(rtcManager);
-
-                expect(localMedia._rtcManagers).toEqual([]);
-            });
-        });
-
-        describe("setMicrophoneDevice", () => {
-            let deviceId: string;
-
-            beforeEach(() => {
-                deviceId = "<some_device_id>";
-            });
-
-            it("should get user media with given audio device id", () => {
-                const localMedia = new LocalMedia({ audio: true });
-
-                localMedia.setMicrophoneDevice(deviceId);
-
-                expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
-                    audio: { deviceId },
-                });
-            });
-
-            describe("when getting new audio track succeeeds", () => {
-                let newAudioTrack: MediaStreamTrack;
-
-                beforeEach(() => {
-                    newAudioTrack = new MockMediaStreamTrack("audio");
-                    mockedMediaDevices.getUserMedia.mockResolvedValueOnce(new MediaStream([newAudioTrack]));
-                });
-
-                it("should emit 'stream_updated' with new track", async () => {
-                    const localMedia = new LocalMedia({ audio: true });
-                    const handler = jest.fn();
-                    localMedia.addEventListener("stream_updated", handler);
-
-                    await localMedia.setMicrophoneDevice(deviceId);
-
-                    expect(handler).toHaveBeenCalled();
-                });
-            });
+            localMediaOptions = { audio: true, video: true };
+            localMedia = new LocalMedia(localMediaOptions);
         });
 
         describe("start()", () => {
-            it("should call getUserMedia with supplied constraints", () => {
-                const mediaConstraints = { audio: false, video: true };
-                const localMedia = new LocalMedia(mediaConstraints);
+            it("should call getStream with default options", async () => {
+                await localMedia.start();
 
-                localMedia.start();
-
-                expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(mediaConstraints);
+                expect(mockedGetStream).toHaveBeenCalledWith(
+                    expect.objectContaining({ audioId: localMediaOptions.audio, videoId: localMediaOptions.video }),
+                    { replaceStream: localMedia.stream }
+                );
             });
 
-            describe("when getUserMedia succeeds", () => {
+            describe("when getStream succeeds", () => {
                 let audioTrack: MediaStreamTrack;
                 let videoTrack: MediaStreamTrack;
 
                 beforeEach(() => {
                     audioTrack = new MockMediaStreamTrack("audio");
                     videoTrack = new MockMediaStreamTrack("video");
-                    mockedMediaDevices.getUserMedia.mockResolvedValueOnce(new MediaStream([audioTrack, videoTrack]));
+                    mockedGetStream.mockImplementationOnce((_, { replaceStream }) => {
+                        const stream = replaceStream || new MockMediaStream();
+                        stream.addTrack(audioTrack);
+                        stream.addTrack(videoTrack);
+                        return Promise.resolve({ stream });
+                    });
                 });
 
                 it("should return a stream with tracks", async () => {
@@ -177,120 +128,207 @@ describe("LocalMedia", () => {
             });
         });
 
-        describe("stop()", () => {
-            it("should stop all tracks", async () => {
-                const audioTrack = new MockMediaStreamTrack("audio");
-                const videoTrack = new MockMediaStreamTrack("video");
-                mockedMediaDevices.getUserMedia.mockResolvedValueOnce(new MediaStream([audioTrack, videoTrack]));
-
+        describe("started instance", () => {
+            beforeEach(async () => {
                 await localMedia.start();
-                localMedia.stop();
-
-                expect(audioTrack.stop).toHaveBeenCalled();
-                expect(videoTrack.stop).toHaveBeenCalled();
             });
-        });
 
-        describe("toggleCameraEnabled()", () => {
-            let localMedia: LocalMedia;
+            describe("addRtcManager()", () => {
+                it("should add the supplied manager to its list of managers", () => {
+                    const rtcManager = new MockRtcManager();
 
-            describe("when camera is enabled", () => {
-                let audioTrack: MediaStreamTrack;
-                let videoTrack: MediaStreamTrack;
+                    localMedia.addRtcManager(rtcManager);
 
-                beforeEach(async () => {
-                    audioTrack = new MockMediaStreamTrack("audio");
-                    videoTrack = new MockMediaStreamTrack("video");
-                    mockedMediaDevices.getUserMedia.mockResolvedValueOnce(new MediaStream([audioTrack, videoTrack]));
-                    localMedia = new LocalMedia({ audio: true, video: true });
+                    expect(localMedia._rtcManagers).toEqual([rtcManager]);
+                });
+            });
 
-                    await localMedia.start();
+            describe("removeRtcManager()", () => {
+                it("should remove the supplied manager from its list of managers", () => {
+                    const rtcManager = new MockRtcManager();
+
+                    localMedia.addRtcManager(rtcManager);
+                    localMedia.removeRtcManager(rtcManager);
+
+                    expect(localMedia._rtcManagers).toEqual([]);
+                });
+            });
+
+            describe("setMicrophoneDevice", () => {
+                let deviceId: string;
+
+                beforeEach(() => {
+                    deviceId = "<some_device_id>";
+                    mockedGetStream.mockResolvedValueOnce({ stream: new MockMediaStream() });
                 });
 
-                [undefined, false].forEach((val) => {
-                    describe(`when called with ${val}`, () => {
-                        it("should stop the existing video track", async () => {
-                            await localMedia.toggleCameraEnabled(val);
+                it("should call getStream with given audio device id", () => {
+                    localMedia.setMicrophoneDevice(deviceId);
 
-                            expect(videoTrack.stop).toHaveBeenCalled();
-                        });
+                    expect(mockedGetStream).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            audioId: deviceId,
+                            videoId: false,
+                        }),
+                        { replaceStream: localMedia.stream }
+                    );
+                });
 
-                        it("`isCameraEnabled()` should be false", async () => {
-                            await localMedia.toggleCameraEnabled(val);
+                describe("when getting new audio track succeeeds", () => {
+                    let newAudioTrack: MediaStreamTrack;
 
-                            expect(localMedia.isCameraEnabled()).toEqual(false);
-                        });
+                    beforeEach(() => {
+                        newAudioTrack = new MockMediaStreamTrack("audio");
+                        mockedGetStream.mockResolvedValueOnce({ stream: new MockMediaStream([newAudioTrack]) });
+                    });
 
-                        it("should dispatch `camera_enabled`", async () => {
-                            const eventListener = jest.fn();
-                            localMedia.addEventListener("camera_enabled", eventListener);
+                    it("should emit 'stream_updated' with new track", async () => {
+                        const handler = jest.fn();
+                        localMedia.addEventListener("stream_updated", handler);
 
-                            await localMedia.toggleCameraEnabled(val);
+                        await localMedia.setMicrophoneDevice(deviceId);
 
-                            expect(eventListener).toHaveBeenCalledWith(
-                                new CustomEvent("camera_enable", { detail: { enabled: false } })
-                            );
-                        });
-
-                        it("should dispatch `stopresumevideo` on stream", async () => {
-                            const eventListener = jest.fn();
-                            localMedia.stream.addEventListener("stopresumevideo", eventListener);
-
-                            await localMedia.toggleCameraEnabled(val);
-
-                            expect(eventListener).toHaveBeenCalledWith(
-                                new CustomEvent("stopresumevideo", { detail: { track: videoTrack, enable: false } })
-                            );
-                        });
+                        expect(handler).toHaveBeenCalled();
                     });
                 });
             });
 
-            describe("when camera is disabled", () => {
-                let newVideoTrack: MediaStreamTrack;
-
-                beforeEach(async () => {
-                    newVideoTrack = new MockMediaStreamTrack("video");
-                    mockedMediaDevices.getUserMedia.mockResolvedValueOnce(new MockMediaStream([]));
-                    mockedMediaDevices.getUserMedia.mockResolvedValueOnce(new MockMediaStream([newVideoTrack]));
-                    localMedia = new LocalMedia({ video: false });
+            describe("stop()", () => {
+                it("should stop all tracks", async () => {
+                    const audioTrack = new MockMediaStreamTrack("audio");
+                    const videoTrack = new MockMediaStreamTrack("video");
+                    mockedGetStream.mockImplementationOnce((_, { replaceStream }) => {
+                        const stream = replaceStream || new MockMediaStream();
+                        stream.addTrack(audioTrack);
+                        stream.addTrack(videoTrack);
+                        return Promise.resolve({ stream });
+                    });
                     await localMedia.start();
+
+                    localMedia.stop();
+
+                    expect(audioTrack.stop).toHaveBeenCalled();
+                    expect(videoTrack.stop).toHaveBeenCalled();
+                });
+            });
+
+            describe("toggleCameraEnabled()", () => {
+                let localMedia: LocalMedia;
+
+                describe("when camera is enabled", () => {
+                    let audioTrack: MediaStreamTrack;
+                    let videoTrack: MediaStreamTrack;
+
+                    beforeEach(async () => {
+                        audioTrack = new MockMediaStreamTrack("audio");
+                        videoTrack = new MockMediaStreamTrack("video");
+                        localMedia = new LocalMedia({ audio: true, video: true });
+
+                        mockedGetStream.mockImplementationOnce((_, { replaceStream }) => {
+                            const stream = replaceStream || new MockMediaStream();
+                            stream.addTrack(audioTrack);
+                            stream.addTrack(videoTrack);
+                            return Promise.resolve({ stream });
+                        });
+
+                        await localMedia.start();
+                    });
+
+                    [undefined, false].forEach((val) => {
+                        describe(`when called with ${val}`, () => {
+                            it("should stop the existing video track", async () => {
+                                await localMedia.toggleCameraEnabled(val);
+
+                                expect(videoTrack.stop).toHaveBeenCalled();
+                            });
+
+                            it("`isCameraEnabled()` should be false", async () => {
+                                await localMedia.toggleCameraEnabled(val);
+
+                                expect(localMedia.isCameraEnabled()).toEqual(false);
+                            });
+
+                            it("should dispatch `camera_enabled`", async () => {
+                                const eventListener = jest.fn();
+                                localMedia.addEventListener("camera_enabled", eventListener);
+
+                                await localMedia.toggleCameraEnabled(val);
+
+                                expect(eventListener).toHaveBeenCalledWith(
+                                    new CustomEvent("camera_enable", { detail: { enabled: false } })
+                                );
+                            });
+
+                            it("should dispatch `stopresumevideo` on stream", async () => {
+                                const eventListener = jest.fn();
+                                localMedia.stream.addEventListener("stopresumevideo", eventListener);
+
+                                await localMedia.toggleCameraEnabled(val);
+
+                                expect(eventListener).toHaveBeenCalledWith(
+                                    new CustomEvent("stopresumevideo", { detail: { track: videoTrack, enable: false } })
+                                );
+                            });
+                        });
+                    });
                 });
 
-                [undefined, true].forEach((val) => {
-                    describe(`when called with ${val}`, () => {
-                        it("should call getUserMedia", async () => {
-                            await localMedia.toggleCameraEnabled(val);
+                describe("when camera is disabled", () => {
+                    let newVideoTrack: MediaStreamTrack;
 
-                            expect(mockMediaDevices.getUserMedia).toBeCalled();
+                    beforeEach(async () => {
+                        localMedia = new LocalMedia({ audio: false, video: false });
+                        mockedGetStream.mockImplementationOnce((_, { replaceStream }) => {
+                            const stream = replaceStream || new MockMediaStream();
+                            return Promise.resolve({ stream });
                         });
+                        await localMedia.start();
 
-                        it("should add new video track to stream", async () => {
-                            await localMedia.toggleCameraEnabled(val);
-
-                            expect(localMedia.stream.getVideoTracks()[0]).toEqual(newVideoTrack);
+                        newVideoTrack = new MockMediaStreamTrack("video");
+                        mockedGetStream.mockImplementationOnce((_, { replaceStream }) => {
+                            const stream = replaceStream || new MockMediaStream();
+                            stream.addTrack(newVideoTrack);
+                            return Promise.resolve({ stream });
                         });
+                    });
 
-                        it("should dispatch `camera_enabled`", async () => {
-                            const eventListener = jest.fn();
-                            localMedia.addEventListener("camera_enabled", eventListener);
+                    [undefined, true].forEach((val) => {
+                        describe(`when called with ${val}`, () => {
+                            it("should call getUserMedia", async () => {
+                                await localMedia.toggleCameraEnabled(val);
 
-                            await localMedia.toggleCameraEnabled(val);
+                                expect(mockedGetStream).toBeCalled();
+                            });
 
-                            expect(eventListener).toHaveBeenCalledWith(
-                                new CustomEvent("camera_enable", { detail: { enabled: true } })
-                            );
-                        });
+                            it("should add new video track to stream", async () => {
+                                await localMedia.toggleCameraEnabled(val);
 
-                        it("should dispatch `stopresumevideo` on stream", async () => {
-                            const eventListener = jest.fn();
-                            localMedia.stream.addEventListener("stopresumevideo", eventListener);
+                                expect(localMedia.stream.getVideoTracks()[0]).toEqual(newVideoTrack);
+                            });
 
-                            await localMedia.toggleCameraEnabled(val);
+                            it("should dispatch `camera_enabled`", async () => {
+                                const eventListener = jest.fn();
+                                localMedia.addEventListener("camera_enabled", eventListener);
 
-                            expect(eventListener).toHaveBeenCalledWith(
-                                new CustomEvent("stopresumevideo", { detail: { track: newVideoTrack, enable: true } })
-                            );
+                                await localMedia.toggleCameraEnabled(val);
+
+                                expect(eventListener).toHaveBeenCalledWith(
+                                    new CustomEvent("camera_enable", { detail: { enabled: true } })
+                                );
+                            });
+
+                            it("should dispatch `stopresumevideo` on stream", async () => {
+                                const eventListener = jest.fn();
+                                localMedia.stream.addEventListener("stopresumevideo", eventListener);
+
+                                await localMedia.toggleCameraEnabled(val);
+
+                                expect(eventListener).toHaveBeenCalledWith(
+                                    new CustomEvent("stopresumevideo", {
+                                        detail: { track: newVideoTrack, enable: true },
+                                    })
+                                );
+                            });
                         });
                     });
                 });

--- a/src/lib/__tests__/RoomConnection.spec.ts
+++ b/src/lib/__tests__/RoomConnection.spec.ts
@@ -24,7 +24,7 @@ describe("RoomConnection", () => {
             const roomKey = "abc";
 
             const roomConnection = new RoomConnection(`https://subdomain.whereby.com/<some-room>?roomKey=${roomKey}`, {
-                localMediaConstraints: { audio: true, video: true },
+                localMediaOptions: { audio: true, video: true },
             });
 
             expect(roomConnection.roomKey).toEqual(roomKey);
@@ -34,7 +34,7 @@ describe("RoomConnection", () => {
             const roomKey = "abc";
 
             const roomConnection = new RoomConnection(`https://subdomain.whereby.com/<some-room>?roomKey=urlKey`, {
-                localMediaConstraints: { audio: true, video: true },
+                localMediaOptions: { audio: true, video: true },
                 roomKey,
             });
 

--- a/src/lib/react/useLocalMedia.ts
+++ b/src/lib/react/useLocalMedia.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useState } from "react";
-import LocalMedia from "../LocalMedia";
+import LocalMedia, { LocalMediaOptions } from "../LocalMedia";
 
 interface LocalMediaState {
     currentCameraDeviceId?: string;
@@ -130,10 +130,12 @@ function reducer(state: LocalMediaState, action: LocalMediaEvents): LocalMediaSt
     }
 }
 
+export type UseLocalMediaOptions = LocalMediaOptions;
+
 export default function useLocalMedia(
-    constraintsOrStream: MediaStreamConstraints | MediaStream = { audio: true, video: true }
+    optionsOrStream: UseLocalMediaOptions | MediaStream = { audio: true, video: true }
 ): LocalMediaRef {
-    const [localMedia] = useState<LocalMedia>(() => new LocalMedia(constraintsOrStream));
+    const [localMedia] = useState<LocalMedia>(() => new LocalMedia(optionsOrStream));
     const [state, dispatch] = useReducer(reducer, initialState);
 
     useEffect(() => {

--- a/src/lib/react/useRoomConnection.ts
+++ b/src/lib/react/useRoomConnection.ts
@@ -431,7 +431,7 @@ export type RoomConnectionRef = {
 };
 
 const defaultRoomConnectionOptions: UseRoomConnectionOptions = {
-    localMediaConstraints: {
+    localMediaOptions: {
         audio: true,
         video: true,
     },

--- a/src/stories/components/VideoExperience.tsx
+++ b/src/stories/components/VideoExperience.tsx
@@ -15,7 +15,7 @@ export default function VideoExperience({
     const [chatMessage, setChatMessage] = useState("");
     const { state, actions, components } = useRoomConnection(roomName, {
         displayName,
-        localMediaConstraints: {
+        localMediaOptions: {
             audio: true,
             video: true,
         },
@@ -23,13 +23,7 @@ export default function VideoExperience({
         logger: console,
     });
 
-    const {
-        localParticipant,
-        remoteParticipants,
-        connectionStatus,
-        waitingParticipants,
-        screenshares,
-    } = state;
+    const { localParticipant, remoteParticipants, connectionStatus, waitingParticipants, screenshares } = state;
     const {
         knock,
         sendChatMessage,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -287,3 +287,52 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         once<K extends keyof SignalEvents>(eventName: K, callback: (args: SignalEvents[K]) => void);
     }
 }
+
+declare module "@whereby/jslib-media/src/webrtc/mediaConstraints" {
+    type GetMediaConstraintsOptions = {
+        disableAEC: boolean;
+        disableAGC: boolean;
+        hd: boolean;
+        lax: boolean;
+        lowDataMode: boolean;
+        preferredDeviceIds: {
+            audioId?: string;
+            videoId?: string;
+        };
+        resolution?: string;
+        simulcast: boolean;
+        widescreen: boolean;
+    };
+
+    export function getMediaConstraints(options: GetMediaConstraintsOptions): MediaStreamConstraints;
+
+    export type GetConstraintsOptions = {
+        devices: MediaDeviceInfo[];
+        audioId?: boolean | string;
+        videoId?: boolean | string;
+        type?: "ideal" | "exact";
+        options: Omit<GetMediaConstraintsOptions, "preferredDeviceIds">;
+    };
+
+    export default function getConstraints(options: GetMediaConstraintsOptions);
+}
+
+declare module "@whereby/jslib-media/src/webrtc/MediaDevices" {
+    import type { GetConstraintsOptions } from "@whereby/jslib-media/src/webrtc/mediaConstraints";
+
+    type GetStreamOptions = {
+        replaceStream?: MediaStream;
+        fallback?: boolean;
+    };
+
+    type GetStreamResult = {
+        error?: unknown;
+        replacedTracks?: MediaStreamTrack[];
+        stream: MediaStream;
+    };
+
+    export function getStream(
+        constraintOpt: GetConstraintsOptions,
+        getStreamOptions: GetStreamOptions
+    ): Promise<GetStreamResult>;
+}


### PR DESCRIPTION
Use shared media constraints helpers to align the SDK with our PWA in how it fetches camera and microphone.

### Tested like
1. yarn dev
2. Verify you get audio/video, verify you can switch devices