### PR TITLE
Clean up log output

### DIFF
--- a/src/lib/RoomConnection.ts
+++ b/src/lib/RoomConnection.ts
@@ -36,7 +36,7 @@ import ServerSocket, {
 import { sdkVersion } from "./version";
 import LocalMedia from "./LocalMedia";
 
-type Logger = Pick<Console, "debug" | "error" | "log" | "warn">;
+type Logger = Pick<Console, "debug" | "error" | "log" | "warn" | "info">;
 
 export interface RoomConnectionOptions {
     displayName?: string; // Might not be needed at all
@@ -305,6 +305,7 @@ export default class RoomConnection extends TypedEventTarget {
         this.logger = logger || {
             debug: noop,
             error: noop,
+            info: noop,
             log: noop,
             warn: noop,
         };
@@ -402,6 +403,7 @@ export default class RoomConnection extends TypedEventTarget {
                 h264On: false,
                 simulcastScreenshareOn: false,
             },
+            logger: this.logger,
         });
     }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,6 +58,13 @@ declare module "@whereby/jslib-media/src/webrtc/RtcManagerDispatcher" {
             h264On: boolean;
             simulcastScreenshareOn: boolean;
         };
+        logger: {
+            debug: (message: string) => void;
+            error: (message: string) => void;
+            info: (message: string) => void;
+            log: (message: string) => void;
+            warn: (message: string) => void;
+        };
     }
     export default class RtcManagerDispatcher {
         constructor(args: ConstructorArgs);


### PR DESCRIPTION
Add noop logger by default to hide media debug log messages from the console.

### Test plan

1. Start your sample app without specifying a `logger` in the room connection config
2. Check your console log => there should be no media related console messages there anymore
3. Add a logger to your room connection config, like
    ```js
    const roomConnection = useRoomConnection(roomUrl, {
        localMediaConstraints: {
            video: true,
            audio: true,
        },
        logger: console,
    });
    ```
4. Start your app => messages like "Connected to signal socket" should be visible in devtool's console.