### PR TITLE
Fix Storybook default args

### DIFF
--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -10,8 +10,12 @@ import "./styles.css";
 export default {
     title: "Examples/Custom UI",
     argTypes: {
-        displayName: { control: "text", defaultValue: "SDK" },
-        roomUrl: { control: "text", defaultValue: process.env.STORYBOOK_ROOM, type: { required: true } },
+        displayName: { control: "text" },
+        roomUrl: { control: "text", type: { required: true } },
+    },
+    args: {
+        displayName: "SDK",
+        roomUrl: process.env.STORYBOOK_ROOM,
     },
 };
 


### PR DESCRIPTION
The new Storybook version handles default arguments differently from the previous. This fixes the issue.

### Tested like

1. Do `yarn dev` with .env file including `STORYBOOK_ROOM=<your_room>`
2. Verify the correct room is being used when connecting