### PR TITLE
Fix build and lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,20 +102,6 @@ function MyCallUX( { roomUrl, localStream }) {
 
 ```
 
-#### Usage with Vite development environment
-
-There is a [known Vite issue](https://github.com/vitejs/vite/issues/1973) where modules trying to access `process.env` throw `Uncaught ReferenceError: process is not defined`.
-This can be solved in `vite.config.js` with the following line:
-
-``` javascript
-export default defineConfig({
-    ...rest,
-    define: {
-        'process.env': {}
-    },
-});
-```
-
 #### Usage with Next.js
 
 If you are integrating these React hooks with Next.js, you need to ensure your

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-alpha28",
+    "version": "2.0.0-beta3",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -102,6 +102,7 @@ module.exports = [
     {
         input: "src/lib/react/index.ts",
         output: [{ file: "dist/react/index.d.ts", format: "es" }],
+        external: ["@whereby/jslib-media/src/webrtc/RtcManager"],
         plugins: [dts()],
     },
     {

--- a/src/lib/__tests__/LocalMedia.spec.ts
+++ b/src/lib/__tests__/LocalMedia.spec.ts
@@ -25,8 +25,6 @@ Object.defineProperty(navigator, "mediaDevices", {
     value: mockMediaDevices,
 });
 
-const mockedMediaDevices = jest.mocked(navigator.mediaDevices);
-
 describe("LocalMedia", () => {
     describe("constructor", () => {
         describe("when passing constraints", () => {

--- a/src/lib/api/credentialsService/index.ts
+++ b/src/lib/api/credentialsService/index.ts
@@ -6,7 +6,7 @@ import ChromeStorageStore from "../modules/ChromeStorageStore";
 import LocalStorageStore from "../modules/LocalStorageStore";
 import ApiClient from "../ApiClient";
 import localStorage from "../localStorageWrapper";
-import { Credentials } from "..";
+import Credentials from "../Credentials";
 
 /**
  * Events triggered by this service


### PR DESCRIPTION
Minor cleanup to remove warnings related to missing types.

### Tested like

`yarn build` should not produce any warnings