### PR TITLE
Add external id to socket events

### DIFF
--- a/src/lib/core/redux/slices/__tests__/app.unit.ts
+++ b/src/lib/core/redux/slices/__tests__/app.unit.ts
@@ -10,6 +10,7 @@ describe("appSlice", () => {
                     roomKey: "roomKey",
                     displayName: "displayName",
                     sdkVersion: "sdkVersion",
+                    externalId: "externalId",
                 })
             );
 
@@ -20,6 +21,7 @@ describe("appSlice", () => {
                 roomKey: "roomKey",
                 displayName: "displayName",
                 sdkVersion: "sdkVersion",
+                externalId: "externalId",
             });
         });
 

--- a/src/lib/core/redux/slices/app.ts
+++ b/src/lib/core/redux/slices/app.ts
@@ -12,6 +12,7 @@ export interface AppState {
     roomKey: string | null;
     displayName: string | null;
     sdkVersion: string | null;
+    externalId: string | null;
 }
 
 const initialState: AppState = {
@@ -21,6 +22,7 @@ const initialState: AppState = {
     roomUrl: null,
     displayName: null,
     sdkVersion: null,
+    externalId: null,
 };
 
 export const appSlice = createSlice({
@@ -35,6 +37,7 @@ export const appSlice = createSlice({
                 roomKey: string | null;
                 roomUrl: string;
                 sdkVersion: string;
+                externalId: string | null;
             }>
         ) => {
             const url = new URL(action.payload.roomUrl);
@@ -73,3 +76,4 @@ export const selectAppRoomUrl = (state: RootState) => state.app.roomUrl;
 export const selectAppRoomKey = (state: RootState) => state.app.roomKey;
 export const selectAppDisplayName = (state: RootState) => state.app.displayName;
 export const selectAppSdkVersion = (state: RootState) => state.app.sdkVersion;
+export const selectAppExternalId = (state: RootState) => state.app.externalId;

--- a/src/lib/core/redux/slices/roomConnection.ts
+++ b/src/lib/core/redux/slices/roomConnection.ts
@@ -3,7 +3,14 @@ import { PayloadAction, createSelector, createSlice } from "@reduxjs/toolkit";
 import { createReactor, startAppListening } from "../listenerMiddleware";
 import { RootState } from "../store";
 import { createAppThunk } from "../thunk";
-import { selectAppDisplayName, selectAppRoomKey, selectAppRoomName, selectAppSdkVersion, setRoomKey } from "./app";
+import {
+    selectAppDisplayName,
+    selectAppRoomKey,
+    selectAppRoomName,
+    selectAppSdkVersion,
+    selectAppExternalId,
+    setRoomKey,
+} from "./app";
 
 import { selectOrganizationId } from "./organization";
 import { signalEvents } from "./signalConnection/actions";
@@ -78,6 +85,7 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
     const roomKey = selectAppRoomKey(state);
     const displayName = selectAppDisplayName(state);
     const sdkVersion = selectAppSdkVersion(state);
+    const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
 
     socket?.emit("knock_room", {
@@ -87,16 +95,16 @@ export const doKnockRoom = createAppThunk(() => (dispatch, getState) => {
             isVideoEnabled: true,
         },
         deviceCapabilities: { canScreenshare: true },
-        displayName: displayName,
+        displayName,
         isCoLocated: false,
         isDevicePermissionDenied: false,
         kickFromOtherRooms: false,
-        organizationId: organizationId,
-        roomKey: roomKey,
-        roomName: roomName,
+        organizationId,
+        roomKey,
+        roomName,
         selfId: "",
         userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
-        externalId: null,
+        externalId,
     });
 
     dispatch(connectionStatusChanged("knocking"));
@@ -109,6 +117,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const roomKey = selectAppRoomKey(state);
     const displayName = selectAppDisplayName(state);
     const sdkVersion = selectAppSdkVersion(state);
+    const externalId = selectAppExternalId(state);
     const organizationId = selectOrganizationId(state);
     const isCameraEnabled = selectIsCameraEnabled(getState());
     const isMicrophoneEnabled = selectIsMicrophoneEnabled(getState());
@@ -120,16 +129,16 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
             isVideoEnabled: isCameraEnabled,
         },
         deviceCapabilities: { canScreenshare: true },
-        displayName: displayName,
+        displayName,
         isCoLocated: false,
         isDevicePermissionDenied: false,
         kickFromOtherRooms: false,
-        organizationId: organizationId,
-        roomKey: roomKey,
-        roomName: roomName,
+        organizationId,
+        roomKey,
+        roomName,
         selfId: "",
         userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
-        externalId: null,
+        externalId,
     });
 
     dispatch(connectionStatusChanged("connecting"));

--- a/src/lib/react/useRoomConnection/index.ts
+++ b/src/lib/react/useRoomConnection/index.ts
@@ -17,6 +17,7 @@ import { appLeft, doAppJoin } from "../../core/redux/slices/app";
 import { selectRoomConnectionState } from "./selector";
 import { doKnockRoom } from "../../core/redux/slices/roomConnection";
 import { doRtcReportStreamResolution } from "../../core/redux/slices/rtcConnection";
+import { sdkVersion } from "../../version";
 
 const initialState: RoomConnectionState = {
     chatMessages: [],
@@ -74,7 +75,8 @@ export function useRoomConnection(
                     : roomConnectionOptions.localMediaOptions,
                 roomKey,
                 roomUrl,
-                sdkVersion: "1.0.0",
+                sdkVersion: sdkVersion,
+                externalId: roomConnectionOptions.externalId || null,
             })
         );
         return () => {


### PR DESCRIPTION
I added this yesterday, but apparently it disappeared during the rebase. Re-adding now.

### Test plan
0. Add `externalId` to `roomConnectionOptions` when calling `useRoomConnection` hook
1. `yarn dev`
2. Verify that `externalId` is passed to socket events (`join_room` and `knock_room`). 

![image](https://github.com/whereby/browser-sdk/assets/6151521/5e7f80df-84ad-47fd-9ef4-83672d8e9715)
