### PR TITLE
Handle reconnect logic

### DIFF
--- a/src/lib/core/redux/slices/remoteParticipants.ts
+++ b/src/lib/core/redux/slices/remoteParticipants.ts
@@ -76,8 +76,8 @@ function updateStreamState(
         return state;
     }
 
+    const idIdx = participant.streams.findIndex((s) => s.id === streamId);
     const streams = [...participant.streams];
-    const idIdx = streams.findIndex((s) => s.id === streamId);
     streams[idIdx] = { ...streams[idIdx], state: state_ };
 
     return updateParticipant(state, participantId, { streams });
@@ -178,9 +178,9 @@ export const remoteParticipantsSlice = createSlice({
         streamStatusUpdated: (state, action: PayloadAction<StreamStatusUpdate[]>) => {
             let newState = state;
 
-            action.payload.forEach((update) => {
-                newState = updateStreamState(newState, update.clientId, update.streamId, update.state);
-            });
+            for (const { clientId, streamId, state } of action.payload) {
+                newState = updateStreamState(newState, clientId, streamId, state);
+            }
 
             return newState;
         },

--- a/src/lib/core/redux/slices/roomConnection.ts
+++ b/src/lib/core/redux/slices/roomConnection.ts
@@ -14,7 +14,11 @@ import {
 
 import { selectOrganizationId } from "./organization";
 import { signalEvents } from "./signalConnection/actions";
-import { selectSignalConnectionDeviceIdentified, selectSignalConnectionRaw } from "./signalConnection";
+import {
+    selectSignalConnectionDeviceIdentified,
+    selectSignalConnectionRaw,
+    socketReconnecting,
+} from "./signalConnection";
 import { selectIsCameraEnabled, selectIsMicrophoneEnabled, selectLocalMediaStatus } from "./localMedia";
 import { selectSelfId } from "./localParticipant";
 
@@ -22,6 +26,7 @@ export type ConnectionStatus =
     | "initializing"
     | "connecting"
     | "connected"
+    | "reconnect"
     | "room_locked"
     | "knocking"
     | "disconnecting"
@@ -67,6 +72,12 @@ export const roomConnectionSlice = createSlice({
             return {
                 ...state,
                 status: "connected",
+            };
+        });
+        builder.addCase(socketReconnecting, (state) => {
+            return {
+                ...state,
+                status: "reconnect",
             };
         });
     },
@@ -162,7 +173,7 @@ export const selectShouldConnectRoom = createSelector(
             localMediaStatus === "started" &&
             signalConnectionDeviceIdentified &&
             !!hasOrganizationIdFetched &&
-            roomConnectionStatus === "initializing"
+            ["initializing", "reconnect"].includes(roomConnectionStatus)
         ) {
             return true;
         }

--- a/src/lib/core/redux/slices/roomConnection.ts
+++ b/src/lib/core/redux/slices/roomConnection.ts
@@ -132,6 +132,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
     const organizationId = selectOrganizationId(state);
     const isCameraEnabled = selectIsCameraEnabled(getState());
     const isMicrophoneEnabled = selectIsMicrophoneEnabled(getState());
+    const selfId = selectSelfId(getState());
 
     socket?.emit("join_room", {
         avatarUrl: null,
@@ -147,7 +148,7 @@ export const doConnectRoom = createAppThunk(() => (dispatch, getState) => {
         organizationId,
         roomKey,
         roomName,
-        selfId: "",
+        selfId,
         userAgent: `browser-sdk:${sdkVersion || "unknown"}`,
         externalId,
     });

--- a/src/lib/core/redux/slices/rtcConnection/index.ts
+++ b/src/lib/core/redux/slices/rtcConnection/index.ts
@@ -2,7 +2,7 @@ import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { AppDispatch, RootState } from "../../store";
 import { createAppThunk } from "../../thunk";
 import RtcManager from "@whereby/jslib-media/src/webrtc/RtcManager";
-import { selectSignalConnectionRaw, selectSignalConnectionSocket } from "../signalConnection";
+import { selectSignalConnectionRaw, selectSignalConnectionSocket, socketReconnecting } from "../signalConnection";
 import RtcManagerDispatcher, {
     RtcEvents,
     RtcManagerCreatedPayload,
@@ -123,6 +123,14 @@ export const rtcConnectionSlice = createSlice({
                 rtcManagerInitialized: true,
             };
         },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(socketReconnecting, (state) => {
+            return {
+                ...state,
+                status: "reconnect",
+            };
+        });
     },
 });
 

--- a/src/lib/core/redux/slices/signalConnection/actions.ts
+++ b/src/lib/core/redux/slices/signalConnection/actions.ts
@@ -28,6 +28,7 @@ export const signalEvents = {
     clientMetadataReceived: createSignalEventAction<ClientMetadataReceivedEvent>("clientMetadataReceived"),
     cloudRecordingStarted: createSignalEventAction<CloudRecordingStartedEvent>("cloudRecordingStarted"),
     cloudRecordingStopped: createSignalEventAction<void>("cloudRecordingStopped"),
+    disconnect: createSignalEventAction<void>("disconnect"),
     knockerLeft: createSignalEventAction<KnockerLeftEvent>("knockerLeft"),
     knockHandled: createSignalEventAction<KnockAcceptedEvent | KnockRejectedEvent>("knockHandled"),
     newClient: createSignalEventAction<NewClientEvent>("newClient"),

--- a/src/lib/core/redux/tests/store.setup.ts
+++ b/src/lib/core/redux/tests/store.setup.ts
@@ -93,6 +93,7 @@ export function createStore({ initialState, withSignalConnection, withRtcManager
             rtcManagerDispatcher: createRtcDispatcher({ emitter: mockRtcEmitter }),
             rtcManagerInitialized: true,
             rtcManager: mockRtcManager,
+            isAcceptingStreams: false,
         };
     }
 

--- a/src/lib/core/redux/tests/store/signalConnection.spec.ts
+++ b/src/lib/core/redux/tests/store/signalConnection.spec.ts
@@ -56,7 +56,6 @@ describe("actions", () => {
         expect(mockSignalEmit).toHaveBeenCalledWith("leave_room");
         expect(mockServerSocket.disconnect).toHaveBeenCalled();
         expect(diff(before, after)).toEqual({
-            socket: null,
             status: "disconnected",
         });
     });
@@ -82,6 +81,7 @@ describe("actions", () => {
         expect(mockSignalEmit).toHaveBeenCalledWith("identify_device", { deviceCredentials });
         expect(diff(before, after)).toEqual({
             isIdentifyingDevice: true,
+            status: "reconnect",
         });
     });
 });

--- a/src/lib/react/useRoomConnection/types.ts
+++ b/src/lib/react/useRoomConnection/types.ts
@@ -24,6 +24,7 @@ export type ConnectionStatus =
     | "initializing"
     | "connecting"
     | "connected"
+    | "reconnect"
     | "room_locked"
     | "knocking"
     | "disconnecting"


### PR DESCRIPTION
Refactor reconnect logic, and make it behave more like the pwa. Make sure that we pass `selfId` to the signal `join_room` event, so that we don't re-create the rtc manager when reconnecting. 

I had to add a dispatch of a `isAcceptingStreams` action in the `doHandleAcceptStreams` fn. This was because in the case of reconnect, this was triggering several times, and I ended up with an infinite loop. There seems to be a race where we start accepting streams again before the function is done. This fix is a bit ugly, but it seems to work well. 

### Tested like
1. Join the room from both your test app and a normal pwa window.
2. Simulate a reconnect by saving a file in signal (need to run local-stack with signal as local-dev).
3. Verify that the test app is reconnected correctly, streams are accepted again  (you can see video both ways).
4. Verify that you only have one websocket connection to the sfu and rtcstats (signal will have 2, since the first one is replaced on reconnect). 