### PR TITLE
Fix camera light not turning off when turning off camera

### DIFF
--- a/src/lib/core/redux/slices/localMedia.ts
+++ b/src/lib/core/redux/slices/localMedia.ts
@@ -322,6 +322,8 @@ export const doStartLocalMedia = createAppAsyncThunk(
 
         if (!(payload.audio || payload.video)) {
             return { stream: new MediaStream() };
+        } else {
+            dispatch(doSetLocalMediaOptions({ options: payload }));
         }
 
         try {

--- a/src/lib/core/redux/slices/localMedia.ts
+++ b/src/lib/core/redux/slices/localMedia.ts
@@ -89,7 +89,7 @@ export const localMediaSlice = createSlice({
                     options: action.payload.localMediaOptions,
                 };
             })
-            .addCase(reactSetDevice.pending, (state, action) => {
+            .addCase(doSetDevice.pending, (state, action) => {
                 const { audio, video } = action.meta.arg;
                 return {
                     ...state,
@@ -97,7 +97,7 @@ export const localMediaSlice = createSlice({
                     isSettingMicrophoneDevice: audio,
                 };
             })
-            .addCase(reactSetDevice.fulfilled, (state, action) => {
+            .addCase(doSetDevice.fulfilled, (state, action) => {
                 const { audio, video } = action.meta.arg;
                 return {
                     ...state,
@@ -105,7 +105,7 @@ export const localMediaSlice = createSlice({
                     isSettingMicrophoneDevice: audio ? false : state.isSettingMicrophoneDevice,
                 };
             })
-            .addCase(reactSetDevice.rejected, (state, action) => {
+            .addCase(doSetDevice.rejected, (state, action) => {
                 const { audio, video } = action.meta.arg;
                 return {
                     ...state,
@@ -115,13 +115,13 @@ export const localMediaSlice = createSlice({
                     microphoneDeviceError: audio ? action.error : state.microphoneDeviceError,
                 };
             })
-            .addCase(reactToggleCamera.pending, (state) => {
+            .addCase(doToggleCamera.pending, (state) => {
                 return {
                     ...state,
                     isTogglingCamera: true,
                 };
             })
-            .addCase(reactToggleCamera.fulfilled, (state) => {
+            .addCase(doToggleCamera.fulfilled, (state) => {
                 return {
                     ...state,
                     isTogglingCamera: false,
@@ -205,7 +205,7 @@ export const {
     stopScreenshare,
 } = localMediaSlice.actions;
 
-const reactToggleCamera = createAppAsyncThunk("localMedia/doToggleCamera", async (_, { getState, rejectWithValue }) => {
+const doToggleCamera = createAppAsyncThunk("localMedia/doToggleCamera", async (_, { getState, rejectWithValue }) => {
     const state = getState();
     const stream = selectLocalMediaStream(state);
     if (!stream) {
@@ -213,8 +213,6 @@ const reactToggleCamera = createAppAsyncThunk("localMedia/doToggleCamera", async
     }
     let track = stream.getVideoTracks()[0];
     const enabled = selectIsCameraEnabled(state);
-
-    // this.dispatchEvent(new LocalMediaEvent("camera_enabled", { detail: { enabled: this._cameraEnabled } }));
 
     // Only stop tracks if we fully own the media stream
     const shouldStopTrack = selectLocalMediaOwnsStream(state);
@@ -260,7 +258,7 @@ const reactToggleCamera = createAppAsyncThunk("localMedia/doToggleCamera", async
     }
 });
 
-const reactToggleMicrophone = createAppAsyncThunk("localMedia/doToggleMicrophone", (_, { getState }) => {
+const doToggleMicrophone = createAppAsyncThunk("localMedia/doToggleMicrophone", (_, { getState }) => {
     const state = getState();
     const stream = selectLocalMediaStream(state);
     if (!stream) {
@@ -275,7 +273,7 @@ const reactToggleMicrophone = createAppAsyncThunk("localMedia/doToggleMicrophone
     audioTrack.enabled = enabled;
 });
 
-export const reactSetDevice = createAppAsyncThunk(
+export const doSetDevice = createAppAsyncThunk(
     "localMedia/reactSetDevice",
     async ({ audio, video }: { audio: boolean; video: boolean }, { getState, rejectWithValue }) => {
         try {
@@ -496,7 +494,7 @@ startAppListening({
         return isReady && oldValue !== newValue;
     },
     effect: (_, { dispatch }) => {
-        dispatch(reactToggleMicrophone());
+        dispatch(doToggleMicrophone());
     },
 });
 
@@ -512,7 +510,7 @@ startAppListening({
         return isReady && oldValue !== newValue;
     },
     effect: (_action, { dispatch }) => {
-        dispatch(reactToggleCamera());
+        dispatch(doToggleCamera());
     },
 });
 
@@ -524,7 +522,7 @@ startAppListening({
         return isReady && oldValue !== newValue;
     },
     effect: (_action, { dispatch }) => {
-        dispatch(reactSetDevice({ audio: false, video: true }));
+        dispatch(doSetDevice({ audio: false, video: true }));
     },
 });
 
@@ -536,6 +534,6 @@ startAppListening({
         return isReady && oldValue !== newValue;
     },
     effect: (_action, { dispatch }) => {
-        dispatch(reactSetDevice({ audio: true, video: false }));
+        dispatch(doSetDevice({ audio: true, video: false }));
     },
 });

--- a/src/lib/core/redux/slices/rtcConnection/index.ts
+++ b/src/lib/core/redux/slices/rtcConnection/index.ts
@@ -17,7 +17,7 @@ import {
     selectIsMicrophoneEnabled,
     selectLocalMediaStream,
     selectLocalMediaStatus,
-    reactSetDevice,
+    doSetDevice,
     doStartScreenshare,
     stopScreenshare,
 } from "../localMedia";
@@ -338,7 +338,7 @@ startAppListening({
 });
 
 startAppListening({
-    actionCreator: reactSetDevice.fulfilled,
+    actionCreator: doSetDevice.fulfilled,
     effect: ({ payload }, { getState }) => {
         const { replacedTracks } = payload;
         const { rtcManager } = selectRtcConnectionRaw(getState());

--- a/src/lib/core/redux/tests/store/localMedia.spec.ts
+++ b/src/lib/core/redux/tests/store/localMedia.spec.ts
@@ -90,6 +90,7 @@ describe("actions", () => {
                         status: "started",
                         stream: newStream,
                         devices: expect.any(Object),
+                        options: { audio: true, video: true },
                     });
                 });
             });

--- a/src/stories/custom-ui.stories.tsx
+++ b/src/stories/custom-ui.stories.tsx
@@ -44,7 +44,7 @@ export const RoomConnectionWithLocalMedia = ({ roomUrl, displayName }: { roomUrl
 };
 
 export const LocalMediaOnly = () => {
-    const localMedia = useLocalMedia();
+    const localMedia = useLocalMedia({ audio: true, video: true });
 
     return (
         <div>


### PR DESCRIPTION
Camera light currently doesn't turn off when cam is disabled. This is because we are relying on the `selectLocalMediaOwnsStream` selector to decide if we should stop the track or not. The problem is that the value of this selector was never set. This solves the issue by populating the local media state with the options whenever we start local media with them. 

### Tested like
1. `yarn dev`
2. Go to a story, like Local media only f.ex
3. Verify cam light is on when the camera is enabled
4. Turn cam off, verify that the cam light goes away. 