### PR TITLE
Remember mute state when switching devices

### DIFF
--- a/src/lib/core/redux/slices/localMedia.ts
+++ b/src/lib/core/redux/slices/localMedia.ts
@@ -298,6 +298,12 @@ export const reactSetDevice = createAppAsyncThunk(
                 { replaceStream: stream }
             );
 
+            const isAudioEnabled = selectIsMicrophoneEnabled(state);
+            stream.getAudioTracks().forEach((track) => (track.enabled = isAudioEnabled));
+
+            const isVideoEnabled = selectIsCameraEnabled(state);
+            stream.getVideoTracks().forEach((track) => (track.enabled = isVideoEnabled));
+
             return { replacedTracks };
         } catch (error) {
             return rejectWithValue(error);


### PR DESCRIPTION
Currently, when you switch device, we ignore the mute state and play the stream. We need to remember the state. 

### Tested like
1. `yarn dev`
2. Go to local media only story
3. Turn off cam
4. Switch cam device
5. Verify that the stream does not start, and the mute state is respected
6. Try enabling/disabling device and switch, verify that it all works as it should