### PR TITLE
Auto switch stream when device is unplugged

### DIFF
--- a/src/lib/core/redux/slices/localMedia.ts
+++ b/src/lib/core/redux/slices/localMedia.ts
@@ -49,26 +49,47 @@ export const localMediaSlice = createSlice({
     name: "localMedia",
     initialState,
     reducers: {
-        doToggleCameraEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
-            state.cameraEnabled = action.payload.enabled ?? !state.cameraEnabled;
+        toggleCameraEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
+            return {
+                ...state,
+                cameraEnabled: action.payload.enabled ?? !state.cameraEnabled,
+            };
         },
-        doSetCurrentCameraDeviceId(state, action: PayloadAction<{ deviceId?: string }>) {
-            state.currentCameraDeviceId = action.payload.deviceId;
+        setCurrentCameraDeviceId(state, action: PayloadAction<{ deviceId?: string }>) {
+            return {
+                ...state,
+                currentCameraDeviceId: action.payload.deviceId,
+            };
         },
-        doToggleMicrophoneEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
-            state.microphoneEnabled = action.payload.enabled ?? !state.microphoneEnabled;
+        toggleMicrophoneEnabled(state, action: PayloadAction<{ enabled?: boolean }>) {
+            return {
+                ...state,
+                microphoneEnabled: action.payload.enabled ?? !state.microphoneEnabled,
+            };
         },
-        doSetCurrentMicrophoneDeviceId(state, action: PayloadAction<{ deviceId?: string }>) {
-            state.currentMicrophoneDeviceId = action.payload.deviceId;
+        setCurrentMicrophoneDeviceId(state, action: PayloadAction<{ deviceId?: string }>) {
+            return {
+                ...state,
+                currentMicrophoneDeviceId: action.payload.deviceId,
+            };
         },
-        doSetDevices(state, action: PayloadAction<{ devices: MediaDeviceInfo[] }>) {
-            state.devices = action.payload.devices;
+        setDevices(state, action: PayloadAction<{ devices: MediaDeviceInfo[] }>) {
+            return {
+                ...state,
+                devices: action.payload.devices,
+            };
         },
-        doSetLocalMediaStream(state, action: PayloadAction<{ stream: MediaStream }>) {
-            state.stream = action.payload.stream;
+        setLocalMediaStream(state, action: PayloadAction<{ stream: MediaStream }>) {
+            return {
+                ...state,
+                stream: action.payload.stream,
+            };
         },
-        doSetLocalMediaOptions(state, action: PayloadAction<{ options: LocalMediaOptions }>) {
-            state.options = action.payload.options;
+        setLocalMediaOptions(state, action: PayloadAction<{ options: LocalMediaOptions }>) {
+            return {
+                ...state,
+                options: action.payload.options,
+            };
         },
         localMediaStopped(state) {
             return {
@@ -79,126 +100,125 @@ export const localMediaSlice = createSlice({
         },
     },
     extraReducers: (builder) => {
-        builder
-            .addCase(doAppJoin, (state, action) => {
-                return {
-                    ...state,
-                    options: action.payload.localMediaOptions,
-                };
-            })
-            .addCase(doSetDevice.pending, (state, action) => {
-                const { audio, video } = action.meta.arg;
-                return {
-                    ...state,
-                    isSettingCameraDevice: video,
-                    isSettingMicrophoneDevice: audio,
-                };
-            })
-            .addCase(doSetDevice.fulfilled, (state, action) => {
-                const { audio, video } = action.meta.arg;
-                return {
-                    ...state,
-                    isSettingCameraDevice: video ? false : state.isSettingCameraDevice,
-                    isSettingMicrophoneDevice: audio ? false : state.isSettingMicrophoneDevice,
-                };
-            })
-            .addCase(doSetDevice.rejected, (state, action) => {
-                const { audio, video } = action.meta.arg;
-                return {
-                    ...state,
-                    isSettingCameraDevice: video ? false : state.isSettingCameraDevice,
-                    isSettingMicrophoneDevice: audio ? false : state.isSettingMicrophoneDevice,
-                    cameraDeviceError: video ? action.error : state.cameraDeviceError,
-                    microphoneDeviceError: audio ? action.error : state.microphoneDeviceError,
-                };
-            })
-            .addCase(doToggleCamera.pending, (state) => {
-                return {
-                    ...state,
-                    isTogglingCamera: true,
-                };
-            })
-            .addCase(doToggleCamera.fulfilled, (state) => {
-                return {
-                    ...state,
-                    isTogglingCamera: false,
-                };
-            })
-            .addCase(doUpdateDeviceList.fulfilled, (state, action) => {
-                return {
-                    ...state,
-                    devices: action.payload.devices,
-                };
-            })
-            .addCase(doStartLocalMedia.pending, (state) => {
-                return {
-                    ...state,
-                    status: "starting",
-                };
-            })
-            .addCase(doStartLocalMedia.fulfilled, (state, { payload: { stream, onDeviceChange } }) => {
-                let cameraDeviceId = undefined;
-                let cameraEnabled = false;
-                let microphoneDeviceId = undefined;
-                let microphoneEnabled = false;
+        builder.addCase(doAppJoin, (state, action) => {
+            return {
+                ...state,
+                options: action.payload.localMediaOptions,
+            };
+        });
+        builder.addCase(doSetDevice.pending, (state, action) => {
+            const { audio, video } = action.meta.arg;
+            return {
+                ...state,
+                isSettingCameraDevice: video,
+                isSettingMicrophoneDevice: audio,
+            };
+        });
+        builder.addCase(doSetDevice.fulfilled, (state, action) => {
+            const { audio, video } = action.meta.arg;
+            return {
+                ...state,
+                isSettingCameraDevice: video ? false : state.isSettingCameraDevice,
+                isSettingMicrophoneDevice: audio ? false : state.isSettingMicrophoneDevice,
+            };
+        });
+        builder.addCase(doSetDevice.rejected, (state, action) => {
+            const { audio, video } = action.meta.arg;
+            return {
+                ...state,
+                isSettingCameraDevice: video ? false : state.isSettingCameraDevice,
+                isSettingMicrophoneDevice: audio ? false : state.isSettingMicrophoneDevice,
+                cameraDeviceError: video ? action.error : state.cameraDeviceError,
+                microphoneDeviceError: audio ? action.error : state.microphoneDeviceError,
+            };
+        });
+        builder.addCase(doToggleCamera.pending, (state) => {
+            return {
+                ...state,
+                isTogglingCamera: true,
+            };
+        });
+        builder.addCase(doToggleCamera.fulfilled, (state) => {
+            return {
+                ...state,
+                isTogglingCamera: false,
+            };
+        });
+        builder.addCase(doUpdateDeviceList.fulfilled, (state, action) => {
+            return {
+                ...state,
+                devices: action.payload.devices,
+            };
+        });
+        builder.addCase(doStartLocalMedia.pending, (state) => {
+            return {
+                ...state,
+                status: "starting",
+            };
+        });
+        builder.addCase(doStartLocalMedia.fulfilled, (state, { payload: { stream, onDeviceChange } }) => {
+            let cameraDeviceId = undefined;
+            let cameraEnabled = false;
+            let microphoneDeviceId = undefined;
+            let microphoneEnabled = false;
 
-                const audioTrack = stream.getAudioTracks()[0];
-                const videoTrack = stream.getVideoTracks()[0];
+            const audioTrack = stream.getAudioTracks()[0];
+            const videoTrack = stream.getVideoTracks()[0];
 
-                if (audioTrack) {
-                    microphoneDeviceId = audioTrack.getSettings().deviceId;
-                    microphoneEnabled = audioTrack.enabled;
-                }
+            if (audioTrack) {
+                microphoneDeviceId = audioTrack.getSettings().deviceId;
+                microphoneEnabled = audioTrack.enabled;
+            }
 
-                if (videoTrack) {
-                    cameraEnabled = videoTrack.enabled;
-                    cameraDeviceId = videoTrack.getSettings().deviceId;
-                }
+            if (videoTrack) {
+                cameraEnabled = videoTrack.enabled;
+                cameraDeviceId = videoTrack.getSettings().deviceId;
+            }
 
-                return {
-                    ...state,
-                    stream,
-                    status: "started",
-                    currentCameraDeviceId: cameraDeviceId,
-                    currentMicrophoneDeviceId: microphoneDeviceId,
-                    cameraEnabled,
-                    microphoneEnabled,
-                    onDeviceChange,
-                };
-            })
-            .addCase(doStartLocalMedia.rejected, (state, action) => {
-                return {
-                    ...state,
-                    status: "error",
-                    startError: action.error,
-                };
-            })
-            .addCase(doSwitchLocalStream.pending, (state) => {
-                return {
-                    ...state,
-                    isSwitchingStream: true,
-                };
-            })
-            .addCase(doSwitchLocalStream.fulfilled, (state) => {
-                const deviceData = getDeviceData({
-                    devices: state.devices,
-                    audioTrack: state.stream?.getAudioTracks()[0],
-                    videoTrack: state.stream?.getVideoTracks()[0],
-                });
-
-                return {
-                    ...state,
-                    isSwitchingStream: false,
-                    currentCameraDeviceId: deviceData.video.deviceId,
-                    currentMicrophoneDeviceId: deviceData.audio.deviceId,
-                };
-            })
-            .addCase(doSwitchLocalStream.rejected, (state) => {
-                return {
-                    ...state,
-                    isSwitchingStream: false,
-                };
+            return {
+                ...state,
+                stream,
+                status: "started",
+                currentCameraDeviceId: cameraDeviceId,
+                currentMicrophoneDeviceId: microphoneDeviceId,
+                cameraEnabled,
+                microphoneEnabled,
+                onDeviceChange,
+            };
+        });
+        builder.addCase(doStartLocalMedia.rejected, (state, action) => {
+            return {
+                ...state,
+                status: "error",
+                startError: action.error,
+            };
+        });
+        builder.addCase(doSwitchLocalStream.pending, (state) => {
+            return {
+                ...state,
+                isSwitchingStream: true,
+            };
+        });
+        builder.addCase(doSwitchLocalStream.fulfilled, (state) => {
+            const deviceData = getDeviceData({
+                devices: state.devices,
+                audioTrack: state.stream?.getAudioTracks()[0],
+                videoTrack: state.stream?.getVideoTracks()[0],
             });
+
+            return {
+                ...state,
+                isSwitchingStream: false,
+                currentCameraDeviceId: deviceData.video.deviceId,
+                currentMicrophoneDeviceId: deviceData.audio.deviceId,
+            };
+        });
+        builder.addCase(doSwitchLocalStream.rejected, (state) => {
+            return {
+                ...state,
+                isSwitchingStream: false,
+            };
+        });
     },
 });
 
@@ -207,12 +227,12 @@ export const localMediaSlice = createSlice({
  */
 
 export const {
-    doSetCurrentCameraDeviceId,
-    doSetCurrentMicrophoneDeviceId,
-    doToggleCameraEnabled,
-    doToggleMicrophoneEnabled,
-    doSetLocalMediaOptions,
-    doSetLocalMediaStream,
+    setCurrentCameraDeviceId,
+    setCurrentMicrophoneDeviceId,
+    toggleCameraEnabled,
+    toggleMicrophoneEnabled,
+    setLocalMediaOptions,
+    setLocalMediaStream,
     localMediaStopped,
 } = localMediaSlice.actions;
 
@@ -448,7 +468,7 @@ export const doStartLocalMedia = createAppAsyncThunk(
         if (!(payload.audio || payload.video)) {
             return { stream: new MediaStream(), onDeviceChange };
         } else {
-            dispatch(doSetLocalMediaOptions({ options: payload }));
+            dispatch(setLocalMediaOptions({ options: payload }));
         }
 
         try {

--- a/src/lib/core/redux/slices/localParticipant.ts
+++ b/src/lib/core/redux/slices/localParticipant.ts
@@ -5,7 +5,7 @@ import { LocalParticipant } from "../../../../lib/react";
 import { selectSignalConnectionRaw } from "./signalConnection";
 
 import { doAppJoin } from "./app";
-import { doToggleCameraEnabled, doToggleMicrophoneEnabled } from "./localMedia";
+import { toggleCameraEnabled, toggleMicrophoneEnabled } from "./localMedia";
 import { startAppListening } from "../listenerMiddleware";
 import { signalEvents } from "./signalConnection/actions";
 
@@ -120,7 +120,7 @@ export const selectLocalParticipantRole = (state: RootState) => state.localParti
 export const selectLocalParticipantIsScreenSharing = (state: RootState) => state.localParticipant.isScreenSharing;
 
 startAppListening({
-    actionCreator: doToggleCameraEnabled,
+    actionCreator: toggleCameraEnabled,
     effect: ({ payload }, { dispatch, getState }) => {
         const { enabled } = payload;
         const { isVideoEnabled } = selectLocalParticipantRaw(getState());
@@ -130,7 +130,7 @@ startAppListening({
 });
 
 startAppListening({
-    actionCreator: doToggleMicrophoneEnabled,
+    actionCreator: toggleMicrophoneEnabled,
     effect: ({ payload }, { dispatch, getState }) => {
         const { enabled } = payload;
         const { isAudioEnabled } = selectLocalParticipantRaw(getState());

--- a/src/lib/core/redux/slices/localScreenshare.ts
+++ b/src/lib/core/redux/slices/localScreenshare.ts
@@ -1,0 +1,137 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createAppAsyncThunk, createAppThunk } from "../thunk";
+import { RootState } from "../store";
+import { startAppListening } from "../listenerMiddleware";
+import { localMediaStopped } from "./localMedia";
+
+export interface LocalScreenshareState {
+    status: "" | "starting" | "active";
+    stream: MediaStream | null;
+    error: unknown | null;
+}
+
+const initialState: LocalScreenshareState = {
+    status: "",
+    stream: null,
+    error: null,
+};
+
+/**
+ * Reducer
+ */
+
+export const localScreenshareSlice = createSlice({
+    name: "localScreenshare",
+    initialState,
+    reducers: {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        stopScreenshare(state, action: PayloadAction<{ stream: MediaStream }>) {
+            return {
+                ...state,
+                status: "",
+                stream: null,
+            };
+        },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(doStartScreenshare.pending, (state) => {
+            return {
+                ...state,
+                status: "starting",
+            };
+        });
+        builder.addCase(doStartScreenshare.fulfilled, (state, { payload: { stream } }) => {
+            return {
+                ...state,
+                status: "active",
+                stream,
+            };
+        });
+        builder.addCase(doStartScreenshare.rejected, (state, { payload }) => {
+            return {
+                ...state,
+                error: payload,
+                status: "",
+                stream: null,
+            };
+        });
+    },
+});
+
+/**
+ * Action creators
+ */
+
+export const { stopScreenshare } = localScreenshareSlice.actions;
+
+export const doStartScreenshare = createAppAsyncThunk(
+    "localScreenshare/doStartScreenshare",
+    async (_, { dispatch, getState, rejectWithValue }) => {
+        try {
+            const state = getState();
+            const screenshareStream = selectLocalScreenshareStream(state);
+
+            if (screenshareStream) {
+                return { stream: screenshareStream };
+            }
+
+            const stream = await navigator.mediaDevices.getDisplayMedia();
+
+            const onEnded = () => {
+                dispatch(doStopScreenshare());
+            };
+
+            if ("oninactive" in stream) {
+                // Chrome
+                stream.addEventListener("inactive", onEnded);
+            } else {
+                // Firefox
+                stream.getVideoTracks()[0]?.addEventListener("ended", onEnded);
+            }
+
+            return { stream };
+        } catch (error) {
+            return rejectWithValue(error);
+        }
+    }
+);
+
+export const doStopScreenshare = createAppThunk(() => (dispatch, getState) => {
+    const state = getState();
+    const screenshareStream = selectLocalScreenshareStream(state);
+
+    if (!screenshareStream) {
+        return;
+    }
+
+    screenshareStream.getTracks().forEach((track) => track.stop());
+    dispatch(stopScreenshare({ stream: screenshareStream }));
+});
+
+/**
+ * Selectors
+ */
+
+export const selectLocalScreenshareRaw = (state: RootState) => state.localScreenshare;
+export const selectLocalScreenshareStatus = (state: RootState) => state.localScreenshare.status;
+export const selectLocalScreenshareStream = (state: RootState) => state.localScreenshare.stream;
+
+/**
+ * Reactors
+ */
+
+startAppListening({
+    actionCreator: localMediaStopped,
+    effect: (_, { getState }) => {
+        const state = getState();
+        const screenshareStream = selectLocalScreenshareStream(state);
+
+        if (!screenshareStream) {
+            return;
+        }
+
+        screenshareStream?.getTracks().forEach((track) => {
+            track.stop();
+        });
+    },
+});

--- a/src/lib/core/redux/slices/remoteParticipants.ts
+++ b/src/lib/core/redux/slices/remoteParticipants.ts
@@ -6,7 +6,7 @@ import { rtcEvents } from "./rtcConnection/actions";
 import { StreamStatusUpdate } from "./rtcConnection/types";
 import { signalEvents } from "./signalConnection/actions";
 import { RtcStreamAddedPayload } from "@whereby/jslib-media/src/webrtc/RtcManagerDispatcher";
-import { selectScreenshareStream } from "./localMedia";
+import { selectLocalScreenshareStream } from "./localScreenshare";
 
 const NON_PERSON_ROLES = ["recorder", "streamer"];
 
@@ -277,7 +277,7 @@ export const selectRemoteParticipantsRaw = (state: RootState) => state.remotePar
 export const selectRemoteParticipants = (state: RootState) => state.remoteParticipants.remoteParticipants;
 
 export const selectScreenshares = createSelector(
-    selectScreenshareStream,
+    selectLocalScreenshareStream,
     selectRemoteParticipants,
     (localScreenshareStream, remoteParticipants) => {
         const screenshares: Screenshare[] = [];

--- a/src/lib/core/redux/slices/rtcAnalytics.ts
+++ b/src/lib/core/redux/slices/rtcAnalytics.ts
@@ -8,12 +8,8 @@ import { selectOrganizationId } from "./organization";
 import { selectLocalParticipantRole, selectSelfId } from "./localParticipant";
 import { selectSignalStatus } from "./signalConnection";
 import { selectDeviceId } from "./deviceCredentials";
-import {
-    selectIsCameraEnabled,
-    selectIsMicrophoneEnabled,
-    selectLocalMediaStream,
-    selectScreenshareStream,
-} from "./localMedia";
+import { selectIsCameraEnabled, selectIsMicrophoneEnabled, selectLocalMediaStream } from "./localMedia";
+import { selectLocalScreenshareStream } from "./localScreenshare";
 
 type RtcAnalyticsCustomEvent = {
     actionType: string;
@@ -45,16 +41,16 @@ export const rtcAnalyticsCustomEvents: { [key: string]: RtcAnalyticsCustomEvent 
         getOutput: (value) => ({ stream: value }),
     },
     localScreenshareStream: {
-        actionType: "localMedia/doStartScreenshare/fulfilled",
+        actionType: "localScreenshare/doStartScreenshare/fulfilled",
         rtcEventName: "localScreenshareStream",
         getValue: (state: RootState) =>
-            selectScreenshareStream(state)
+            selectLocalScreenshareStream(state)
                 ?.getTracks()
                 .map((track) => ({ id: track.id, kind: track.kind, label: track.label })),
         getOutput: (value) => ({ tracks: value }),
     },
     localScreenshareStreamStopped: {
-        actionType: "localMedia/stopScreenshare",
+        actionType: "localScreeenshare/stopScreenshare",
         rtcEventName: "localScreenshareStream",
         getValue: () => () => null,
         getOutput: () => ({}),

--- a/src/lib/core/redux/slices/rtcConnection/index.ts
+++ b/src/lib/core/redux/slices/rtcConnection/index.ts
@@ -18,12 +18,11 @@ import {
     selectLocalMediaStream,
     selectLocalMediaStatus,
     doSetDevice,
-    doStartScreenshare,
-    stopScreenshare,
 } from "../localMedia";
 import { rtcEvents } from "./actions";
 import { StreamStatusUpdate } from "./types";
 import { signalEvents } from "../signalConnection/actions";
+import { doStartScreenshare, stopScreenshare } from "../localScreenshare";
 
 export const createWebRtcEmitter = (dispatch: AppDispatch) => {
     return {

--- a/src/lib/core/redux/store.ts
+++ b/src/lib/core/redux/store.ts
@@ -8,6 +8,7 @@ import { cloudRecordingSlice } from "./slices/cloudRecording";
 import { deviceCredentialsSlice } from "./slices/deviceCredentials";
 import { localMediaSlice } from "./slices/localMedia";
 import { localParticipantSlice } from "./slices/localParticipant";
+import { localScreenshareSlice } from "./slices/localScreenshare";
 import { organizationSlice } from "./slices/organization";
 import { remoteParticipantsSlice } from "./slices/remoteParticipants";
 import { roomConnectionSlice } from "./slices/roomConnection";
@@ -26,6 +27,7 @@ export const rootReducer = combineReducers({
     deviceCredentials: deviceCredentialsSlice.reducer,
     localMedia: localMediaSlice.reducer,
     localParticipant: localParticipantSlice.reducer,
+    localScreenshare: localScreenshareSlice.reducer,
     organization: organizationSlice.reducer,
     remoteParticipants: remoteParticipantsSlice.reducer,
     roomConnection: roomConnectionSlice.reducer,

--- a/src/lib/core/redux/tests/store/localMedia.spec.ts
+++ b/src/lib/core/redux/tests/store/localMedia.spec.ts
@@ -1,12 +1,13 @@
-import { doStartLocalMedia, doStopLocalMedia } from "../../slices/localMedia";
+import * as localMediaSlice from "../../slices/localMedia";
 import { createStore } from "../store.setup";
 import { diff } from "deep-object-diff";
-import { getStream } from "@whereby/jslib-media/src/webrtc/MediaDevices";
+import * as MediaDevices from "@whereby/jslib-media/src/webrtc/MediaDevices";
 
 import MockMediaStream from "../../../../__mocks__/MediaStream";
 import MockMediaStreamTrack from "../../../../__mocks__/MediaStreamTrack";
 import mockMediaDevices from "../../../../__mocks__/mediaDevices";
 import { RootState } from "../../store";
+import { randomString } from "../../../../__mocks__/appMocks";
 
 Object.defineProperty(window, "MediaStream", {
     writable: true,
@@ -26,9 +27,11 @@ Object.defineProperty(navigator, "mediaDevices", {
 jest.mock("@whereby/jslib-media/src/webrtc/MediaDevices", () => ({
     __esModule: true,
     getStream: jest.fn(() => Promise.resolve()),
+    getUpdatedDevices: jest.fn(() => Promise.resolve({ addedDevices: {}, changedDevices: {} })),
 }));
 
-const mockedGetStream = jest.mocked(getStream);
+const mockedGetStream = jest.mocked(MediaDevices.getStream);
+const mockedEnumerateDevices = jest.mocked(navigator.mediaDevices.enumerateDevices);
 
 describe("actions", () => {
     describe("doStartLocalMedia", () => {
@@ -42,7 +45,7 @@ describe("actions", () => {
             it("should NOT get stream", async () => {
                 const store = createStore();
 
-                await store.dispatch(doStartLocalMedia(existingStream));
+                await store.dispatch(localMediaSlice.doStartLocalMedia(existingStream));
 
                 expect(mockedGetStream).toHaveBeenCalledTimes(0);
             });
@@ -52,7 +55,7 @@ describe("actions", () => {
 
                 const before = store.getState().localMedia;
 
-                await store.dispatch(doStartLocalMedia(existingStream));
+                await store.dispatch(localMediaSlice.doStartLocalMedia(existingStream));
 
                 const after = store.getState().localMedia;
 
@@ -68,7 +71,7 @@ describe("actions", () => {
             it("should call getStream", async () => {
                 const store = createStore();
 
-                await store.dispatch(doStartLocalMedia({ audio: true, video: true }));
+                await store.dispatch(localMediaSlice.doStartLocalMedia({ audio: true, video: true }));
 
                 expect(mockedGetStream).toHaveBeenCalledTimes(1);
             });
@@ -86,7 +89,7 @@ describe("actions", () => {
 
                     const before = store.getState().localMedia;
 
-                    await store.dispatch(doStartLocalMedia({ audio: true, video: true }));
+                    await store.dispatch(localMediaSlice.doStartLocalMedia({ audio: true, video: true }));
 
                     const after = store.getState().localMedia;
 
@@ -114,6 +117,7 @@ describe("actions", () => {
 
                 initialState = {
                     localMedia: {
+                        busyDeviceIds: [],
                         cameraEnabled: true,
                         devices: [],
                         isSettingCameraDevice: false,
@@ -130,7 +134,7 @@ describe("actions", () => {
             it("should stop all tracks in existing stream", () => {
                 const store = createStore({ initialState });
 
-                store.dispatch(doStopLocalMedia());
+                store.dispatch(localMediaSlice.doStopLocalMedia());
 
                 expect(audioTrack.stop).toHaveBeenCalled();
                 expect(videoTrack.stop).toHaveBeenCalled();
@@ -141,7 +145,7 @@ describe("actions", () => {
 
                 const before = store.getState().localMedia;
 
-                store.dispatch(doStopLocalMedia());
+                store.dispatch(localMediaSlice.doStopLocalMedia());
 
                 const after = store.getState().localMedia;
 
@@ -150,6 +154,143 @@ describe("actions", () => {
                     stream: undefined,
                 });
             });
+        });
+    });
+
+    describe("doUpdateDeviceList", () => {
+        it("should switch to the next video device if current cam is unplugged", async () => {
+            const dev1 = {
+                deviceId: "dev1",
+                kind: "videoinput" as const,
+                label: randomString("label"),
+                groupId: randomString("groupId"),
+                toJSON: () => ({}),
+            };
+            const dev2 = {
+                deviceId: "dev2",
+                kind: "videoinput" as const,
+                label: randomString("label"),
+                groupId: randomString("groupId"),
+                toJSON: () => ({}),
+            };
+
+            const store = createStore({
+                initialState: {
+                    localMedia: {
+                        busyDeviceIds: [],
+                        currentCameraDeviceId: dev2.deviceId,
+                        cameraEnabled: true,
+                        devices: [dev1, dev2],
+                        isSettingCameraDevice: false,
+                        isSettingMicrophoneDevice: false,
+                        isTogglingCamera: false,
+                        microphoneEnabled: true,
+                        status: "started",
+                        stream: new MockMediaStream(),
+                        isSwitchingStream: false,
+                    },
+                },
+            });
+            jest.spyOn(localMediaSlice, "doSwitchLocalStream");
+            jest.spyOn(MediaDevices, "getUpdatedDevices").mockImplementationOnce(() => ({
+                addedDevices: {},
+                changedDevices: { videoinput: dev2 },
+            }));
+
+            mockedEnumerateDevices.mockImplementationOnce(() => Promise.resolve([dev1]));
+
+            const before = store.getState().localMedia;
+
+            await store.dispatch(localMediaSlice.doUpdateDeviceList());
+
+            const after = store.getState().localMedia;
+
+            expect(mockedEnumerateDevices).toHaveBeenCalled();
+            expect(localMediaSlice.doSwitchLocalStream).toHaveBeenCalledWith({
+                audioId: undefined,
+                videoId: dev1.deviceId,
+            });
+            expect(diff(before, after)).toMatchObject({
+                devices: {
+                    1: undefined,
+                },
+            });
+        });
+
+        it("should skip busy devices", async () => {
+            const videoId = randomString("videoDeviceId");
+            const videoId2 = randomString("videoDeviceId2");
+            const videoId3 = randomString("videoDeviceId3");
+
+            const dev1 = {
+                deviceId: videoId,
+                kind: "videoinput" as const,
+                label: randomString("label"),
+                groupId: randomString("groupId"),
+                toJSON: () => ({}),
+            };
+            const dev2 = {
+                deviceId: videoId2,
+                kind: "videoinput" as const,
+                label: randomString("label"),
+                groupId: randomString("groupId"),
+                toJSON: () => ({}),
+            };
+            const dev3 = {
+                deviceId: videoId3,
+                kind: "videoinput" as const,
+                label: randomString("label"),
+                groupId: randomString("groupId"),
+                toJSON: () => ({}),
+            };
+
+            const stream = new MockMediaStream();
+            jest.spyOn(MediaDevices, "getStream").mockResolvedValueOnce({ stream });
+
+            const store = createStore({
+                initialState: {
+                    localMedia: {
+                        busyDeviceIds: [videoId2],
+                        currentCameraDeviceId: videoId,
+                        cameraEnabled: true,
+                        devices: [dev1, dev2, dev3],
+                        isSettingCameraDevice: false,
+                        isSettingMicrophoneDevice: false,
+                        isTogglingCamera: false,
+                        microphoneEnabled: true,
+                        status: "started",
+                        stream,
+                        isSwitchingStream: false,
+                    },
+                },
+            });
+            jest.spyOn(localMediaSlice, "doSwitchLocalStream");
+            jest.spyOn(MediaDevices, "getUpdatedDevices").mockImplementationOnce(() => ({
+                addedDevices: {},
+                changedDevices: { videoinput: dev3 },
+            }));
+
+            mockedEnumerateDevices.mockImplementationOnce(() => Promise.resolve([dev1, dev2]));
+
+            const before = store.getState().localMedia;
+
+            await store.dispatch(localMediaSlice.doUpdateDeviceList());
+
+            const after = store.getState().localMedia;
+
+            expect(diff(before, after)).toMatchObject({
+                busyDeviceIds: {
+                    1: expect.any(String),
+                },
+                devices: {
+                    2: undefined,
+                },
+            });
+            expect(localMediaSlice.doSwitchLocalStream).toHaveBeenCalledWith({
+                audioId: undefined,
+                videoId: videoId3,
+            });
+            expect(mockedEnumerateDevices).toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/core/redux/tests/store/localMedia.spec.ts
+++ b/src/lib/core/redux/tests/store/localMedia.spec.ts
@@ -117,6 +117,7 @@ describe("actions", () => {
                         microphoneEnabled: true,
                         status: "started",
                         stream: new MockMediaStream([audioTrack, videoTrack]),
+                        isSwitchingStream: false,
                     },
                 };
             });

--- a/src/lib/core/redux/tests/store/localMedia.spec.ts
+++ b/src/lib/core/redux/tests/store/localMedia.spec.ts
@@ -56,7 +56,11 @@ describe("actions", () => {
 
                 const after = store.getState().localMedia;
 
-                expect(diff(before, after)).toEqual({ status: "started", stream: existingStream });
+                expect(diff(before, after)).toEqual({
+                    status: "started",
+                    stream: existingStream,
+                    onDeviceChange: expect.any(Function),
+                });
             });
         });
 
@@ -91,6 +95,7 @@ describe("actions", () => {
                         stream: newStream,
                         devices: expect.any(Object),
                         options: { audio: true, video: true },
+                        onDeviceChange: expect.any(Function),
                     });
                 });
             });

--- a/src/lib/core/redux/tests/store/localScreenshare.spec.ts
+++ b/src/lib/core/redux/tests/store/localScreenshare.spec.ts
@@ -1,0 +1,62 @@
+import { diff } from "deep-object-diff";
+import { doStartScreenshare, doStopScreenshare } from "../../slices/localScreenshare";
+import { createStore, mockRtcManager } from "../store.setup";
+
+import MockMediaStream from "../../../../__mocks__/MediaStream";
+
+Object.defineProperty(navigator, "mediaDevices", {
+    writable: true,
+    value: {
+        getDisplayMedia: jest.fn(),
+    },
+});
+
+const mockedGetDisplayMedia = jest.mocked(navigator.mediaDevices.getDisplayMedia);
+
+describe("actions", () => {
+    let stream: MediaStream;
+
+    beforeEach(() => {
+        stream = new MockMediaStream();
+    });
+
+    it("doStartScreenshare", async () => {
+        mockedGetDisplayMedia.mockResolvedValue(stream);
+        const store = createStore({
+            withRtcManager: true,
+        });
+
+        const before = store.getState().localScreenshare;
+
+        await store.dispatch(doStartScreenshare());
+
+        const after = store.getState().localScreenshare;
+
+        expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled();
+        expect(mockRtcManager.addNewStream).toHaveBeenCalledWith(stream.id, stream, false, true);
+        expect(diff(before, after)).toEqual({
+            status: "active",
+            stream,
+        });
+    });
+
+    it("doStopScreenshare", async () => {
+        mockedGetDisplayMedia.mockResolvedValue(stream);
+        const store = createStore({
+            withRtcManager: true,
+        });
+
+        await store.dispatch(doStartScreenshare());
+
+        const before = store.getState().localScreenshare;
+
+        store.dispatch(doStopScreenshare());
+
+        const after = store.getState().localScreenshare;
+
+        expect(diff(before, after)).toEqual({
+            status: "",
+            stream: null,
+        });
+    });
+});

--- a/src/lib/react/useLocalMedia/index.ts
+++ b/src/lib/react/useLocalMedia/index.ts
@@ -6,13 +6,11 @@ import {
     doStopLocalMedia,
     doToggleCameraEnabled,
     doToggleMicrophoneEnabled,
-    doUpdateDeviceList,
 } from "../../core/redux/slices/localMedia";
 import { LocalMediaState, UseLocalMediaOptions, UseLocalMediaResult } from "./types";
 import { selectLocalMediaState } from "./selector";
 import { createStore, observeStore, Store } from "../../core/redux/store";
 import { createServices } from "../../services";
-import debounce from "../../utils/debounce";
 
 const initialState: LocalMediaState = {
     cameraDeviceError: null,

--- a/src/lib/react/useLocalMedia/index.ts
+++ b/src/lib/react/useLocalMedia/index.ts
@@ -6,11 +6,13 @@ import {
     doStopLocalMedia,
     doToggleCameraEnabled,
     doToggleMicrophoneEnabled,
+    doUpdateDeviceList,
 } from "../../core/redux/slices/localMedia";
 import { LocalMediaState, UseLocalMediaOptions, UseLocalMediaResult } from "./types";
 import { selectLocalMediaState } from "./selector";
 import { createStore, observeStore, Store } from "../../core/redux/store";
 import { createServices } from "../../services";
+import debounce from "../../utils/debounce";
 
 const initialState: LocalMediaState = {
     cameraDeviceError: null,
@@ -32,9 +34,11 @@ export function useLocalMedia(
         return createStore({ injectServices: services });
     });
     const [localMediaState, setLocalMediaState] = useState(initialState);
+
     useEffect(() => {
         const unsubscribe = observeStore(store, selectLocalMediaState, setLocalMediaState);
         store.dispatch(doStartLocalMedia(optionsOrStream));
+
         return () => {
             unsubscribe();
             store.dispatch(doStopLocalMedia());

--- a/src/lib/react/useLocalMedia/index.ts
+++ b/src/lib/react/useLocalMedia/index.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import {
-    doSetCurrentCameraDeviceId,
-    doSetCurrentMicrophoneDeviceId,
+    setCurrentCameraDeviceId,
+    setCurrentMicrophoneDeviceId,
     doStartLocalMedia,
     doStopLocalMedia,
-    doToggleCameraEnabled,
-    doToggleMicrophoneEnabled,
+    toggleCameraEnabled,
+    toggleMicrophoneEnabled,
 } from "../../core/redux/slices/localMedia";
 import { LocalMediaState, UseLocalMediaOptions, UseLocalMediaResult } from "./types";
 import { selectLocalMediaState } from "./selector";
@@ -44,19 +44,16 @@ export function useLocalMedia(
     }, []);
 
     const setCameraDevice = useCallback(
-        (deviceId: string) => store.dispatch(doSetCurrentCameraDeviceId({ deviceId })),
+        (deviceId: string) => store.dispatch(setCurrentCameraDeviceId({ deviceId })),
         [store]
     );
     const setMicrophoneDevice = useCallback(
-        (deviceId: string) => store.dispatch(doSetCurrentMicrophoneDeviceId({ deviceId })),
+        (deviceId: string) => store.dispatch(setCurrentMicrophoneDeviceId({ deviceId })),
         [store]
     );
-    const toggleCameraEnabled = useCallback(
-        (enabled?: boolean) => store.dispatch(doToggleCameraEnabled({ enabled })),
-        [store]
-    );
-    const toggleMicrophoneEnabled = useCallback(
-        (enabled?: boolean) => store.dispatch(doToggleMicrophoneEnabled({ enabled })),
+    const toggleCamera = useCallback((enabled?: boolean) => store.dispatch(toggleCameraEnabled({ enabled })), [store]);
+    const toggleMicrophone = useCallback(
+        (enabled?: boolean) => store.dispatch(toggleMicrophoneEnabled({ enabled })),
         [store]
     );
     return {
@@ -64,8 +61,8 @@ export function useLocalMedia(
         actions: {
             setCameraDevice,
             setMicrophoneDevice,
-            toggleCameraEnabled,
-            toggleMicrophoneEnabled,
+            toggleCameraEnabled: toggleCamera,
+            toggleMicrophoneEnabled: toggleMicrophone,
         },
         store,
     };

--- a/src/lib/react/useRoomConnection/index.ts
+++ b/src/lib/react/useRoomConnection/index.ts
@@ -7,12 +7,8 @@ import { doSendChatMessage } from "../../core/redux/slices/chat";
 import { doStartCloudRecording, doStopCloudRecording } from "../../core/redux/slices/cloudRecording";
 import { doAcceptWaitingParticipant, doRejectWaitingParticipant } from "../../core/redux/slices/waitingParticipants";
 import { doSetDisplayName } from "../../core/redux/slices/localParticipant";
-import {
-    doToggleCameraEnabled,
-    doToggleMicrophoneEnabled,
-    doStartScreenshare,
-    doStopScreenshare,
-} from "../../core/redux/slices/localMedia";
+import { doToggleCameraEnabled, doToggleMicrophoneEnabled } from "../../core/redux/slices/localMedia";
+import { doStartScreenshare, doStopScreenshare } from "../../core/redux/slices/localScreenshare";
 import { appLeft, doAppJoin } from "../../core/redux/slices/app";
 import { selectRoomConnectionState } from "./selector";
 import { doKnockRoom } from "../../core/redux/slices/roomConnection";

--- a/src/lib/react/useRoomConnection/index.ts
+++ b/src/lib/react/useRoomConnection/index.ts
@@ -7,7 +7,7 @@ import { doSendChatMessage } from "../../core/redux/slices/chat";
 import { doStartCloudRecording, doStopCloudRecording } from "../../core/redux/slices/cloudRecording";
 import { doAcceptWaitingParticipant, doRejectWaitingParticipant } from "../../core/redux/slices/waitingParticipants";
 import { doSetDisplayName } from "../../core/redux/slices/localParticipant";
-import { doToggleCameraEnabled, doToggleMicrophoneEnabled } from "../../core/redux/slices/localMedia";
+import { toggleCameraEnabled, toggleMicrophoneEnabled } from "../../core/redux/slices/localMedia";
 import { doStartScreenshare, doStopScreenshare } from "../../core/redux/slices/localScreenshare";
 import { appLeft, doAppJoin } from "../../core/redux/slices/app";
 import { selectRoomConnectionState } from "./selector";
@@ -117,11 +117,11 @@ export function useRoomConnection(
         [store]
     );
     const toggleCamera = React.useCallback(
-        (enabled?: boolean) => store.dispatch(doToggleCameraEnabled({ enabled })),
+        (enabled?: boolean) => store.dispatch(toggleCameraEnabled({ enabled })),
         [store]
     );
     const toggleMicrophone = React.useCallback(
-        (enabled?: boolean) => store.dispatch(doToggleMicrophoneEnabled({ enabled })),
+        (enabled?: boolean) => store.dispatch(toggleMicrophoneEnabled({ enabled })),
         [store]
     );
     const acceptWaitingParticipant = React.useCallback(

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -3,7 +3,7 @@ interface Options {
     edges?: boolean;
 }
 
-interface DebouncedFunction {
+export interface DebouncedFunction {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (...args: any[]): void;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -343,4 +343,58 @@ declare module "@whereby/jslib-media/src/webrtc/MediaDevices" {
         constraintOpt: GetConstraintsOptions,
         getStreamOptions?: GetStreamOptions
     ): Promise<GetStreamResult>;
+
+    export function enumerate(): Promise<MediaDeviceInfo[]>;
+
+    export function getUpdatedDevices({
+        oldDevices,
+        newDevices,
+        currentAudioId,
+        currentVideoId,
+        currentSpeakerId,
+    }: {
+        oldDevices: MediaDeviceInfo[];
+        newDevices: MediaDeviceInfo[];
+        currentAudioId?: string | undefined;
+        currentVideoId?: string | undefined;
+        currentSpeakerId?: string | undefined;
+    }): {
+        addedDevices: {
+            audioinput?: { deviceId: string; label: string; kind: string };
+            videoinput?: { deviceId: string; label: string; kind: string };
+            audiooutput?: { deviceId: string; label: string; kind: string };
+        };
+        changedDevices: {
+            audioinput?: { deviceId: string; label: string; kind: string };
+            videoinput?: { deviceId: string; label: string; kind: string };
+            audiooutput?: { deviceId: string; label: string; kind: string };
+        };
+    };
+
+    export function getDeviceData({
+        audioTrack,
+        videoTrack,
+        devices,
+        stoppedVideoTrack,
+        lastAudioId,
+        lastVideoId,
+    }: {
+        audioTrack?: MediaStreamTrack | null;
+        videoTrack?: MediaStreamTrack | null;
+        devices: MediaDeviceInfo[];
+        stoppedVideoTrack?: boolean;
+        lastAudioId?: string | undefined;
+        lastVideoId?: string | undefined;
+    }): {
+        audio: {
+            deviceId: string;
+            label: string;
+            kind: string;
+        };
+        video: {
+            deviceId: string;
+            label: string;
+            kind: string;
+        };
+    };
 }


### PR DESCRIPTION
### Description

Sorry for the big PR on this small bugfix, but we didn't really handle switching of streams at all, so I had to add a bunch of logic. Also did some refactoring.

**Summary:**

* Handle unplugging of external devices (Auto-switch stream to next device)
* Handle busy devices, store a list of them in the state, and don't try to switch to a busy device
* Refactor local media slice. Aligning it with the rest of the slices, action creator naming, reducer structure etc
* Add a new slice for local screenshare. Moving the screenshare stuff out of local media and in to a dedicated slice.

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Test with storybook.
2. Verify that all local media functionality works as before
3. Change the camera device to an external one
4. Unplug it
5. Verify that the stream switches to the next device in the list
6. Plug the camera back
7. Verify that the stream does not switch automatically, but that the camera becomes available for manual switching

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Dependency Updates

<!-- If this PR includes dependency updates, please list them here along with
the reason for the update. -->

### Reviewers

<!-- Tag the relevant team members or maintainers who should review this PR.
-->

@havardholvik
@kevinwhereby
@nandito
@thyal

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
