### PR TITLE
Add workflow Dependabot PR -> Linear issue

### DIFF
--- a/.github/workflows/dependabot-pr-linear-issue.yml
+++ b/.github/workflows/dependabot-pr-linear-issue.yml
@@ -1,0 +1,14 @@
+name: Dependabot PR -> Linear issue
+on:
+    pull_request:
+        branches: [main]
+        types: [opened]
+jobs:
+    create_linear_issue_if_needed:
+        name: "Create Linear issue if needed"
+        uses: whereby/github-actions/.github/workflows/dependabot_pr_to_linear_issue.yml@1.0.1
+        secrets:
+            linear_api_key: ${{ secrets.LINEAR_API_KEY }}
+        with:
+            linear_team_id: ${{ vars.LINEAR_PANDA_TEAM_ID }}
+            linear_state_id: ${{ vars.LINEAR_TRIAGE_STATE_ID }}


### PR DESCRIPTION
### Description
Adds workflow which checks if a PR is opened by dependabot and creates Linear issue for timely handling of the proposed change.

### Testing
Nothing to test, will take into effect on the next PR opened by Dependabot

### Checklist

-   [x] My code follows the project's coding standards.
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.
