### PR TITLE
Handle room session id

### DIFF
--- a/src/lib/core/redux/slices/__tests__/remoteParticipants.unit.ts
+++ b/src/lib/core/redux/slices/__tests__/remoteParticipants.unit.ts
@@ -32,6 +32,7 @@ describe("remoteParticipantsSlice", () => {
                                 },
                             ],
                             knockers: [],
+                            session: null,
                         },
                     })
                 );

--- a/src/lib/core/redux/slices/__tests__/roomConnection.unit.ts
+++ b/src/lib/core/redux/slices/__tests__/roomConnection.unit.ts
@@ -17,6 +17,7 @@ describe("roomConnectionSlice", () => {
 
                 expect(result).toEqual({
                     status: "room_locked",
+                    session: null,
                     error: null,
                 });
             });
@@ -33,6 +34,7 @@ describe("roomConnectionSlice", () => {
 
                 expect(result).toEqual({
                     status: "connected",
+                    session: null,
                     error: null,
                 });
             });

--- a/src/lib/core/redux/slices/__tests__/waitingParticipants.unit.ts
+++ b/src/lib/core/redux/slices/__tests__/waitingParticipants.unit.ts
@@ -24,6 +24,7 @@ describe("reducer", () => {
                                 userId: null,
                             },
                         ],
+                        session: null,
                     },
                 })
             );

--- a/src/lib/core/redux/slices/rtcAnalytics.ts
+++ b/src/lib/core/redux/slices/rtcAnalytics.ts
@@ -17,6 +17,7 @@ import { selectSignalStatus } from "./signalConnection";
 import { selectDeviceId } from "./deviceCredentials";
 import { doSetDevice, selectIsCameraEnabled, selectIsMicrophoneEnabled, selectLocalMediaStream } from "./localMedia";
 import { doStartScreenshare, selectLocalScreenshareStream, stopScreenshare } from "./localScreenshare";
+import { selectRoomConnectionSessionId } from "./roomConnection";
 
 type RtcAnalyticsCustomEvent = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -98,6 +99,12 @@ export const rtcAnalyticsCustomEvents: { [key: string]: RtcAnalyticsCustomEvent 
         rtcEventName: "signalConnectionStatus",
         getValue: (state: RootState) => selectSignalStatus(state),
         getOutput: (value) => ({ status: value }),
+    },
+    roomSessionId: {
+        action: null,
+        rtcEventName: "roomSessionId",
+        getValue: (state: RootState) => selectRoomConnectionSessionId(state),
+        getOutput: (value) => ({ roomSessionId: value }),
     },
     rtcConnectionStatus: {
         action: null,

--- a/src/lib/core/redux/slices/signalConnection/actions.ts
+++ b/src/lib/core/redux/slices/signalConnection/actions.ts
@@ -15,6 +15,7 @@ import {
     ScreenshareStartedEvent,
     ScreenshareStoppedEvent,
     VideoEnabledEvent,
+    RoomSessionEndedEvent,
 } from "@whereby/jslib-media/src/utils/ServerSocket";
 
 function createSignalEventAction<T>(name: string) {
@@ -34,6 +35,7 @@ export const signalEvents = {
     newClient: createSignalEventAction<NewClientEvent>("newClient"),
     roomJoined: createSignalEventAction<RoomJoinedEvent>("roomJoined"),
     roomKnocked: createSignalEventAction<RoomKnockedEvent>("roomKnocked"),
+    roomSessionEnded: createSignalEventAction<RoomSessionEndedEvent>("roomSessionEnded"),
     screenshareStarted: createSignalEventAction<ScreenshareStartedEvent>("screenshareStarted"),
     screenshareStopped: createSignalEventAction<ScreenshareStoppedEvent>("screenshareStopped"),
     streamingStopped: createSignalEventAction<void>("streamingStopped"),

--- a/src/lib/core/redux/slices/signalConnection/index.ts
+++ b/src/lib/core/redux/slices/signalConnection/index.ts
@@ -19,6 +19,7 @@ function forwardSocketEvents(socket: ServerSocket, dispatch: ThunkDispatch<RootS
     socket.on("chat_message", (payload) => dispatch(signalEvents.chatMessage(payload)));
     socket.on("disconnect", () => dispatch(signalEvents.disconnect()));
     socket.on("room_knocked", (payload) => dispatch(signalEvents.roomKnocked(payload)));
+    socket.on("room_session_ended", (payload) => dispatch(signalEvents.roomSessionEnded(payload)));
     socket.on("knocker_left", (payload) => dispatch(signalEvents.knockerLeft(payload)));
     socket.on("knock_handled", (payload) => dispatch(signalEvents.knockHandled(payload)));
     socket.on("screenshare_started", (payload) => dispatch(signalEvents.screenshareStarted(payload)));

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -167,6 +167,12 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
     }
     interface NewClientEvent {
         client: SignalClient;
+        room?: {
+            session: {
+                createdAt: string;
+                id: string;
+            } | null;
+        };
     }
 
     interface KnockerLeftEvent {
@@ -193,6 +199,10 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         room?: {
             clients: SignalClient[];
             knockers: SignalKnocker[];
+            session: {
+                createdAt: string;
+                id: string;
+            } | null;
         };
         selfId: string;
     }
@@ -202,6 +212,10 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         displayName: string | null;
         imageUrl: string | null;
         liveVideo: boolean;
+    }
+
+    interface RoomSessionEndedEvent {
+        roomSessionId: string;
     }
 
     interface ScreenshareStartedEvent {
@@ -243,6 +257,7 @@ declare module "@whereby/jslib-media/src/utils/ServerSocket" {
         room_joined: RoomJoinedEvent;
         room_knocked: RoomKnockedEvent;
         room_left: void;
+        room_session_ended: RoomSessionEndedEvent;
         screenshare_started: ScreenshareStartedEvent;
         screenshare_stopped: ScreenshareStoppedEvent;
         streaming_stopped: void;


### PR DESCRIPTION
### Description

We don't handle `roomSessionId` currently. This lead to RTC stats not uploading data for clients connected with the SDK. 
This PR adds `roomSessionId` in state on `roomJoined` and `newClient` signal events, and passes it to RTC stats. 

**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Join a room with the SDK and another client
2. Verify that the `roomSessionId` is present in the redux state

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [x] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Dependency Updates

<!-- If this PR includes dependency updates, please list them here along with
the reason for the update. -->

### Reviewers

<!-- Tag the relevant team members or maintainers who should review this PR.
-->

@havardholvik
@kevinwhereby
@nandito
@thyal

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
