### PR TITLE
Final tweaks before removing the beta tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws-region: eu-west-1
 
-            - uses: jakejarvis/s3-sync-action@master
+            - uses: jakejarvis/s3-sync-action@v0.5.1
               with:
                   args: --acl public-read --follow-symlinks
               env:
@@ -68,7 +68,7 @@ jobs:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: "es-west-1"
-                  SOURCE_DIR: "dist/"
+                  SOURCE_DIR: "dist/cdn/"
                   DEST_DIR: "embed/"
 
             - name: Invalidate cloudfront publication

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whereby.com/browser-sdk",
-    "version": "2.0.0-beta4",
+    "version": "2.0.0",
     "description": "Modules for integration Whereby video in web apps",
     "author": "Whereby AS",
     "license": "MIT",


### PR DESCRIPTION
### Description
Some small adjustments before the 2.0.0 release:

- CDN assets now have a `-embed` part to allow for eg a `-react` build in the future
- CDN assets are now placed in `dist/cdn` to enable clear separation
- Deploy workflow only uploads `dist/cdn` to CDN
- CDN build is now in iife format. A global `whereby` variable is declared containing the exports of the given entrypoint
- Pin version of Github action used to sync data to S3

**NOTE!**
A follow-up PR will be required to also make some adjustments to the support/v1 branch so legacy builds are put in `dist/cdn`, as the deployment workflow changes will affect any release.

### Testing

1. Create a simple web page, something like

```
<html>
  <head>
    <script src="https://cdn.srv.whereby.com/embed/v1.js" type="module"></script>
  </head>

  <body>
    <whereby-embed id="room" room="<YOUR ROOM" />
    <script type="text/javascript">
      const room = document.getElementById("room");

      room.addEventListener("ready", () => console.log("READY!"));
      room.addEventListener("join", () => console.log("JOINED"));
    </script>
  </body>
</html>
```
2. Start a webserver in the dir of the index.html (I use a global npm package `http-server`) 
3. Visit the root of your webpage, verify you see the embedded room and you are able to join
4. Check out this branch, do `yarn build`
5. Copy `dist/cdn/v2-embed.js` next to your index.html
6. Update the index.html to use the v2-embed.js file
7. Refresh, verify you get the embedded room
8. Try joining, verify you see `JOINED` in the console
9. In your index.html, remove `type="module"` in the script tag
10. Refresh, verify you are still able to embed and join
11. In the console, verify you have a `whereby` global variable with the SDK version 

