### PR TITLE
Send a dummy insightsStats event to rtc stats

### DIFF
--- a/src/lib/core/redux/slices/rtcAnalytics.ts
+++ b/src/lib/core/redux/slices/rtcAnalytics.ts
@@ -170,6 +170,17 @@ export const doRtcAnalyticsCustomEventsInitialize = createAppThunk(() => (dispat
 
     if (!rtcManager) return;
 
+    // RTC stats require a `insightsStats` event to be sent to set the timestamp.
+    // This is a temporary workaround, we just send one dummy event on initialization.
+    rtcManager.sendStatsCustomEvent("insightsStats", {
+        _time: Date.now(),
+        ls: 0,
+        lr: 0,
+        bs: 0,
+        br: 0,
+        cpu: 0,
+    });
+
     Object.values(rtcAnalyticsCustomEvents).forEach(({ rtcEventName, getValue, getOutput }) => {
         const value = getValue(state);
         const output = { ...(getOutput(value) as Record<string, unknown>), _time: Date.now() };

--- a/src/lib/core/redux/tests/store/rtcAnalytics.spec.ts
+++ b/src/lib/core/redux/tests/store/rtcAnalytics.spec.ts
@@ -1,4 +1,4 @@
-import { createStore } from "../store.setup";
+import { createStore, mockRtcManager } from "../store.setup";
 import { doRtcAnalyticsCustomEventsInitialize, rtcAnalyticsState } from "../../slices/rtcAnalytics";
 import { diff } from "deep-object-diff";
 
@@ -27,5 +27,6 @@ describe("actions", () => {
                 "userRole",
             ])
         );
+        expect(mockRtcManager.sendStatsCustomEvent).toHaveBeenCalledWith("insightsStats", expect.any(Object));
     });
 });


### PR DESCRIPTION
### Description

The participant insights on the dashboard requires a `timeStamp` to be able to display the timeline of events. 
RTC stats only sets the `timeStamp` property on the first `insightsStats` event. Since we are not sending these events from the SDK yet, this PR adds a dummy event, so that the timestamp gets populated.


**Summary:**

<!-- Provide a brief overview of what this PR does or aims to achieve. -->

**Related Issue:**

<!-- Link to the GitHub issue that this PR addresses, if applicable. -->

### Testing

1. Start a session with a few clients 
2. Toggle microphone / camera from the SDK client a few times
3. End the session
4. Go to the insights dashboard and find the session
5. Find the SDK participant, and verify that the timeline is correctly populated with the events

### Screenshots/GIFs (if applicable)

<!-- Include any screenshots or GIFs that help visualize the changes made,
especially for UI-related changes. -->

### Checklist

-   [x] My code follows the project's coding standards.
-   [ ] I have written unit tests (if applicable).
-   [ ] I have updated the documentation (if applicable).
-   [x] By submitting this pull request, I confirm that my contribution is made
        under the terms of the MIT license.

### Dependency Updates

<!-- If this PR includes dependency updates, please list them here along with
the reason for the update. -->

### Reviewers

<!-- Tag the relevant team members or maintainers who should review this PR.
-->

@havardholvik
@kevinwhereby
@nandito
@thyal

### Additional Information

<!-- Add any additional information that you think is relevant for the review,
such as context, background, or links to related resources. -->
